### PR TITLE
fix: Give example on how to follow theme colors when used with Service

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,7 +6,7 @@ on:
       - '.idea/**'
       - 'preview/**'
       - 'jitpack.yml'
-      - '*.md'
+      - '**/*.md'
       - '.gitignore'
   workflow_dispatch:
 

--- a/app-service-hilt/Readme.md
+++ b/app-service-hilt/Readme.md
@@ -31,3 +31,13 @@ This is mostly just a sample project on how to incorporate hilt into viewmodels 
 
 ![compose-floating-window](https://github.com/user-attachments/assets/2201f599-137d-48ba-8c79-66eb86461fa3)
 
+Note:
+- Service is not aware of the App's theme colors. There is a need to pass the Default Themeing in this app's case `ComposeFloatingWindowTheme` and you can decide if you'll changed it to fix theme or use preference to update the theme
+
+```kotlin
+val darkMode by model.darkMode.collectAsStateWithLifecycle(false)
+
+ComposeFloatingWindowTheme(darkTheme = darkMode) {
+```
+
+![Theme floating window](https://github.com/user-attachments/assets/22b446ce-34b5-4ba0-955c-b270f3c30f90)

--- a/app-service-hilt/src/main/java/com/github/only52607/compose/window/hilt/MainActivity.kt
+++ b/app-service-hilt/src/main/java/com/github/only52607/compose/window/hilt/MainActivity.kt
@@ -17,7 +17,6 @@ import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -28,7 +27,6 @@ import com.github.only52607.compose.window.hilt.ui.DialogPermission
 import com.github.only52607.compose.window.hilt.ui.theme.ComposeFloatingWindowTheme
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.flow.distinctUntilChanged
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @AndroidEntryPoint

--- a/app-service-hilt/src/main/java/com/github/only52607/compose/window/hilt/ui/FloatingWindowContent.kt
+++ b/app-service-hilt/src/main/java/com/github/only52607/compose/window/hilt/ui/FloatingWindowContent.kt
@@ -23,8 +23,9 @@ fun FloatingWindowContent(
 ) {
     val floatingWindow = LocalFloatingWindow.current
 
-    ComposeFloatingWindowTheme {
-        val darkMode by model.darkMode.collectAsStateWithLifecycle(false)
+    val darkMode by model.darkMode.collectAsStateWithLifecycle(false)
+
+    ComposeFloatingWindowTheme(darkTheme = darkMode) {
 
         if (model.dialogVisible) {
             SystemAlertDialog(

--- a/app-service-hilt/src/main/java/com/github/only52607/compose/window/hilt/ui/FloatingWindowContent.kt
+++ b/app-service-hilt/src/main/java/com/github/only52607/compose/window/hilt/ui/FloatingWindowContent.kt
@@ -13,9 +13,9 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.lifecycle.viewmodel.compose.viewModel
 import com.github.only52607.compose.window.LocalFloatingWindow
 import com.github.only52607.compose.window.dragFloatingWindow
+import com.github.only52607.compose.window.hilt.ui.theme.ComposeFloatingWindowTheme
 
 @Composable
 fun FloatingWindowContent(
@@ -23,32 +23,34 @@ fun FloatingWindowContent(
 ) {
     val floatingWindow = LocalFloatingWindow.current
 
-    val darkMode by model.darkMode.collectAsStateWithLifecycle(false)
+    ComposeFloatingWindowTheme {
+        val darkMode by model.darkMode.collectAsStateWithLifecycle(false)
 
-    if (model.dialogVisible) {
-        SystemAlertDialog(
-            onDismissRequest = { model.dismissDialog() },
-            confirmButton = {
-                TextButton(onClick = { model.dismissDialog() }) {
-                    Text(text = "OK")
+        if (model.dialogVisible) {
+            SystemAlertDialog(
+                onDismissRequest = { model.dismissDialog() },
+                confirmButton = {
+                    TextButton(onClick = { model.dismissDialog() }) {
+                        Text(text = "OK")
+                    }
+                },
+                text = {
+                    Text(
+                        text = "This is now ${if (darkMode) "Dark" else "Light"} mode",
+                    )
                 }
+            )
+        }
+        FloatingActionButton(
+            modifier = Modifier.dragFloatingWindow(),
+            onClick = {
+                model.showDialog(!darkMode)
             },
-            text = {
-                Text(
-                    text = "This is now ${if (darkMode) "Dark" else "Light"} mode",
-                )
-            }
-        )
-    }
-    FloatingActionButton(
-        modifier = Modifier.dragFloatingWindow(),
-        onClick = {
-            model.showDialog(!darkMode)
-        },
-        elevation = FloatingActionButtonDefaults.elevation(
-            defaultElevation = 0.dp
-        )
-    ) {
-        Icon(Icons.Filled.Call, "Call")
+            elevation = FloatingActionButtonDefaults.elevation(
+                defaultElevation = 0.dp
+            )
+        ) {
+            Icon(Icons.Filled.Call, "Call")
+        }
     }
 }

--- a/app-service-hilt/src/main/java/com/github/only52607/compose/window/hilt/ui/theme/Theme.kt
+++ b/app-service-hilt/src/main/java/com/github/only52607/compose/window/hilt/ui/theme/Theme.kt
@@ -11,11 +11,11 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
-import androidx.compose.ui.graphics.Color
 
 private val surfaceDark = Color(0xFF101417)
 private val onSurfaceDark = Color(0xFFE0E3E8)
@@ -71,9 +71,12 @@ fun ComposeFloatingWindowTheme(
     val view = LocalView.current
     if (!view.isInEditMode) {
         SideEffect {
-            val window = (view.context as Activity).window
-            window.statusBarColor = colorScheme.primary.toArgb()
-            WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars = darkTheme
+            if (view.context is Activity) {
+                val window = (view.context as Activity).window
+                window.statusBarColor = colorScheme.primary.toArgb()
+                WindowCompat.getInsetsController(window, view).isAppearanceLightStatusBars =
+                    darkTheme
+            }
         }
     }
 

--- a/app-service-hilt/src/main/java/com/github/only52607/compose/window/hilt/ui/theme/Theme.kt
+++ b/app-service-hilt/src/main/java/com/github/only52607/compose/window/hilt/ui/theme/Theme.kt
@@ -55,16 +55,14 @@ private val LightColorScheme = lightColorScheme(
 @Composable
 fun ComposeFloatingWindowTheme(
     darkTheme: Boolean = isSystemInDarkTheme(),
-    // Dynamic color is available on Android 12+
-    dynamicColor: Boolean = true,
     content: @Composable () -> Unit
 ) {
-    val colorScheme = when {
-        dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
-            val context = LocalContext.current
-            if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
-        }
+    val context = LocalContext.current
+    val dynamicColor = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
 
+    val colorScheme = when {
+        dynamicColor && darkTheme -> dynamicDarkColorScheme(context)
+        dynamicColor && !darkTheme -> dynamicLightColorScheme(context)
         darkTheme -> DarkColorScheme
         else -> LightColorScheme
     }


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Fixed the floating window to follow colors when used inside service. Service is not aware of the app's theme color hence uses the default white. This PR gives example on how to give theming when used with service.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->
![NVIDIA_Overlay_FZ9XiL2fs1](https://github.com/user-attachments/assets/495dfe83-a1cf-4c5b-b21e-7fa094733c2e)



## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

## Additional context
<!-- Add any other context about the pull request here. -->