### PR TITLE
fix: prevent floating window jumps after drag and resize

### DIFF
--- a/.agents/skills/android-cli/SKILL.md
+++ b/.agents/skills/android-cli/SKILL.md
@@ -1,0 +1,207 @@
+---
+name: android-cli
+description: Orchestrates Android development tasks including project creation, deployment, SDK management, and environment diagnostics using the `android` command-line tool.
+license: Complete terms in LICENSE.txt
+metadata:
+  author: Google LLC
+  keywords:
+  - sdk
+  - emulator
+  - skills
+  - docs
+  - knowledge base
+  - project creation
+  - screenshots
+---
+# Android CLI Specialist
+
+This skill provides instructions for using the `android` CLI tool. The tool includes various commands for creating projects, running applications, interacting with devices, and managing the CLI environment.
+
+## SDK management
+To manage the installation of Android SDKs and tools, use the `sdk` command. For example:
+
+- `android sdk install <package>[@<version>]...`: Install specific packages. Multiple packages can be specified, separated by spaces. `<version>` defaults to latest. For example: `android sdk install platforms/android-30@2 platforms/android-34`
+- `android sdk update [<pkg-name>]`: Update a specific package or all packages to the latest version.
+- `android sdk remove <pkg-name>`: Remove a package from the local SDK.
+- `android sdk list --all`: List installed and available SDK packages.
+
+## Project creation
+Create projects from templates using the `create` command.
+
+For example: `android create empty-activity --name="My App" --output=./my-app`
+
+## Interacting with devices
+For more information on interacting with running devices, see [here](references/interact.md)
+
+## Running journey tests
+For more information on running journeys, see [here](references/journeys.md)
+
+## Doc searching
+The `docs` command searches authoritative, high-quality Android developer documentation in the Android Knowledge Base.
+By providing a few keywords, this tool will return high quality articles that contain examples or guidance on how to use Android APIs or libraries.
+Use this tool to obtain additional information on how to achieve Android-specific tasks or to know more about Android APIs, surfaces, libraries, or devices.
+
+Always use this tool to get the most up-to-date information about Android concepts. Typical good use cases are:
+  - Finding migration guides for APIs.
+  - Finding examples for APIs.
+  - Finding up-to-date information about Android APIs.
+  - Finding best practices for Android concepts.
+
+## Running APKs
+Use the `run` command to run Android apps.
+
+## Managing emulators
+
+Manage Android Virtual Devices (AVDs) using the `android emulator` command
+
+## Capturing screenshots
+
+Capture an image of the current screen of a connected Android device and output it to a file using the `android screenshot` command.
+
+## Managing skills
+
+Manage antigravity agent skills for Android using the `android skills` command.
+
+## Inspecting UI Layouts
+
+Use the `android layout` command to inspect the UI layout of an Android application. It returns the layout tree of an Android application in JSON format. When debugging UI errors, this is often a much faster approach than taking a screenshot.
+
+## Updating the CLI
+
+Update the Android CLI using the `android update` command.
+
+# `android help` output
+
+Usage: android [-hV] [--sdk=PARAM] [COMMAND]
+  -h, --help        Show this help message and exit.
+      --sdk=PARAM   Path to the Android SDK
+  -V, --version     Print version information and exit.
+Commands:
+  create    Create a new Android project
+  describe  Analyzes an Android project to generate descriptive metadata.
+  docs      Android documentation commands
+  emulator  Emulator commands
+  help      Shows the help of all commands
+  info      Print environment information (SDK Location, etc.)
+  init      Initializes the environment (eg. skills) for Android CLI.
+  layout    Returns the layout tree of an application
+  run       Deploy an Android Application
+  screen    Commands to view the device
+  sdk       Download and list SDK packages
+  skills    Manage skills
+  update    Update the Android CLI
+
+create
+          Usage: android create [-h] [--verbose] [--list] [--minSdk=api]
+                                --name=applicationName [-o=dest-path] [template-name]
+          Create a new Android project
+                [template-name]      The template name
+            -h, --help               Show this help message and exit.
+                --minSdk=api         The 'minSdk' supported by the application (default
+                                       is defined in the template)
+                --name=applicationName
+                                     The name of the application (e.g. 'My Application')
+            -o, --output=dest-path   The destination project directory path (default is
+                                       '.')
+                --verbose            Enables verbose output
+                --list               List all available templates
+
+describe
+          Usage: android describe [-hV] [--project_dir=PARAM]
+          Analyzes an Android project to generate descriptive metadata.
+          This command identifies and outputs the paths to JSON files that detail the
+          project's structure, including build targets and their corresponding output
+          artifact locations (e.g., APKs). This information enables other tools and
+          commands to locate build artifacts efficiently.
+            -h, --help                Show this help message and exit.
+                --project_dir=PARAM   The project directory to describe
+            -V, --version             Print version information and exit.
+
+docs
+          Usage: android docs [-h] [COMMAND]
+          Android documentation commands
+            -h, --help   Show this help message and exit.
+          Commands:
+            search  Search Android documentation
+            fetch   Fetch Android documentation
+
+emulator
+          Usage: android emulator [-h] [COMMAND]
+          Emulator commands
+            -h, --help   Show this help message and exit.
+          Commands:
+            create  Creates a virtual device
+            start   Launches the specified virtual device. This command will return when
+                      the emulator is fully started and ready to use.
+            stop    Stops the specified virtual device
+            list    Lists available virtual devices
+            remove  Delete a virtual device
+
+help
+          Usage: android help [COMMAND]
+          Shows the help of all commands
+                [COMMAND]   The command to show help for
+
+info
+          Usage: android info <field>
+          Print environment information (SDK Location, etc.)
+                <field>   The specific field to print the value of. If omitted print all.
+
+init
+          Usage: android init
+          Initializes the environment (eg. skills) for Android CLI.
+
+layout
+          Usage: android layout [-dhp] [--device=PARAM] [-o=PARAM]
+          Returns the layout tree of an application
+            -d, --diff           Returns a flat list of the layout elements that have
+                                   changed since the last invocation of ui-dump
+                --device=PARAM   The device serial number
+            -h, --help           Show this help message and exit.
+            -o, --output=PARAM   Writes the layout tree to the specified file or
+                                   directory. If omitted, prints the tree to standard
+                                   output
+            -p, --pretty         Pretty-prints the returned JSON
+
+run
+          Usage: android run [-h] [--debug] [--activity=PARAM] [--device=PARAM]
+                             [--type=PARAM] [--apks=PARAM[,PARAM...]]...
+          Deploy an Android Application
+                --activity=PARAM   The activity name
+                --apks=PARAM[,PARAM...]
+                                   The paths to the APKs
+                --debug            Run in debug mode
+                --device=PARAM     The device serial number
+            -h, --help             Show this help message and exit.
+                --type=PARAM       The component type (ACTIVITY, SERVICE, etc.)
+
+screen
+          Usage: android screen [-h] [COMMAND]
+          Commands to view the device
+            -h, --help   Show this help message and exit.
+          Commands:
+            capture  Outputs the device screen to a PNG
+            resolve  Target UI elements visually
+
+sdk
+          Usage: android sdk [COMMAND]
+          Download and list SDK packages
+          Commands:
+            install  Install SDK packages
+            update   Update one or all packages to the latest version
+            remove   Remove a package from the SDK
+            list     List installed and available SDK packages
+
+skills
+          Usage: android skills [COMMAND]
+          Manage skills
+          Commands:
+            add     Install a skill
+            remove  Remove a skill
+            list    List available skills
+            find    Find skills by keyword
+
+update
+          Usage: android update [--url=PARAM]
+          Update the Android CLI
+                --url=PARAM   The URL to download the update from

--- a/.agents/skills/android-cli/references/interact.md
+++ b/.agents/skills/android-cli/references/interact.md
@@ -1,0 +1,83 @@
+# Tools
+Run `android layout --help` and `android screen --help`.
+
+## UI Dump
+`android layout`  returns a flat JSON list of the UI elements on screen.
+`android layout --diff` returns a flat JSON list of the UI elements that have changed since the last call to `layout` or `layout --diff`
+
+Each JSON object represents a UI element in the Android app. The following properties may be present:
+- `text` - any literal text the element contains
+- `resourceId` - the Android resource id used to refer to the element
+- `contentDesc` - a description of a UI element for use by accessibility tools
+- `interactions` - the set of user interactions the element supports. May contain one or more of: `checkable`, `clickable`, `focusable`, `scrollable`, `long-clickable`, `password`
+- `state` - the set of states the element is in. May contain one or more of `checked`, `focused`, `selected`
+- `bounds` - the screen coordinates of the bounding rectangle of the element, in the format `[min X,min Y][max X, max Y]`
+- `center` - the screen coordinates of the center of the element, in the format `[x,y]`
+- `off-screen` - if true, the element is in the UI hierarchy but not visible; it may require scrolling to view.
+
+Use `layout` as a primary means of examining an Android app. Use `layout --diff` to focus on changes and to keep your context small.
+Example: When entering digits into a calculator, use `layout --diff` to output only the digit readout element.
+
+`layout` may fail due to the app displaying a WebView or animation; in these cases, use `android screen --annotate` to inspect the app.
+This failure will likely resolve after navigating away from the current screen.
+
+## Screenshot
+`android screen capture -o <file path>` saves a PNG of the current device screen to `<file path>`
+
+Use `screen capture` as a secondary means of examining an Android app
+Examples:
+- Understanding the content of an on-screen image
+- Looking at a `WebView` (web content does not always appear in the ui dump)
+- Trying to find a UI element by its visual appearance
+
+**IMPORTANT**: Always *VISUALLY* examine the PNG image returned from `android screen` BEFORE doing anything else.
+
+## Annotated Screenshot
+`android screen capture --annotate -o <file path>`
+`android screen resolve --screen <path> --string <string>`
+
+The `--annotate` command adds numerical labels and bounding boxes around UI elements. Use this command to locate UI elements that cannot
+be located in the `layout` output.
+
+**IMPORTANT**: When using `android screen --annotate`, always *VISUALLY* examine the resulting PNG file.
+
+To refer to these labels in input commands, use `screen resolve` to convert labels into coordinates:
+
+`android screen resolve --screen <file path> --string "#3"` returns `<x coord of region 3> <y coord of region 3>`
+
+To save turns, you can combine shell commands:
+
+`adb shell input $(android screen resolve --screen screen.png --string "tap #34")`
+
+This command taps on region #34 from `screen.png`
+
+## Input
+Use `adb shell input` for interacting with Android devices.
+Refer to the `"interactions"` property of an element for what interactions can be performed on a particular element.
+
+Interact with UI elements with their `center` coordinate or their `bounds` coordinates:
+```json
+{
+  "key": -248568265,
+  "class": "android.widget.Button",
+  "bounds": "[138,9][167,38]",
+  "center": "[152,23]"
+}
+```
+To tap on this button, you would execute `adb shell input tap 152 23`. This taps the center.
+
+```json
+{
+  "key": 12487234,
+  "class": "com.example.ui.ScrollableList",
+  "bounds": "[100,200][400,600]",
+  "center": "[250,400]"
+}
+```
+To scroll down on this list, you would execute `adb shell input swipe 250 400 600 500`. This swipes from the center to the bottom over 500ms.
+
+# Android Interaction Rules
+1. Always ensure text input fields have `"focused"` in their `"state"` list before entering text
+2. If an element has `"scrollable"` in its `"interactions"` list, try scrolling it when looking for missing UI elements
+2. Always scroll slowly when executing scroll inputs. The 5th argument to `adb shell input swipe` controls scroll duration.
+3. Content may take time to load; if a `layout` is missing information after you take an action, wait a few seconds, then perform `layout --diff` to see if anything changes.

--- a/.agents/skills/android-cli/references/journeys.md
+++ b/.agents/skills/android-cli/references/journeys.md
@@ -1,0 +1,97 @@
+A journey is an XML-specified test of an Android app's behavior. It consists of a list of `<action>` elements. For example:
+```xml
+<journey name="My Journey">
+   <description>
+      A sample journey to illustrate the format
+   </description>
+   <actions>
+     <action>
+       Tap the "Home" icon
+     </action>
+     <action>
+       Verify that the app is on its Home screen
+     </action>
+   </actions>
+</journey>
+```
+
+Evaluate a journey by proceeding through the `<actions>` list in sequential order. Evaluate each `<action>` block individually.
+A journey succeeds if all elements in the `<actions>` list succeed.
+
+A journey is a test case for an app. The journey XML is the source of truth; if the app disagrees with the journey, the app has failed.
+Additionally, if the app exits, crashes, or freezes, journey evaluation stops and the journey fails.
+
+**IMPORTANT** - Execute each step EXACTLY as written, and independently of other steps! If an action says to `"tap the first search result"`,
+you MUST find the search results and tap the first one. Do this even if you believe you know the intent behind the action.
+
+## Taking Actions
+Some `<action>` elements specify UI interactions to perform on the running Android app. Perform the interaction and verify that the app does 
+not crash or behave in an unexpected manner. This is the *only* verification you should perform for an `<action>`.
+
+If the interaction cannot be performed as specified, the journey fails. 
+Example: 
+```<action>Click the red button</action>```
+If you determine a red button is not present in the UI, the journey fails. 
+
+If the text of an `<action>` specifies a list of actions, break it into sub-actions and evaluate them individually: 
+Example:
+```<action>Search for soda and add the first result to the cart</action>```
+This should be evaluated as:
+```
+<action>Search for soda</action>
+<action>Add the first result to the cart</action>
+```
+
+If an `<action>` contains something that is not a specification for a UI interaction, alert the user that the journey is malformed and exit
+early, specifying the error in question.
+
+## Verifying Expectations
+`<action>` elements that begin with "check" or "verify" specify expectations for the current state of the Android app. Determine the current
+state of the app and check if the expectations are met.
+
+Determine the current state of the app by inspecting the current screen of the device without interacting with it.
+Example:
+```<action>Check if "Switch 2" is visible on the screen</action>```
+This requires only inspecting the current screen, not scrolling or interacting. If "Switch 2" is not currently visible, the action fails.
+
+If the expectations are not met, mark the `<action>` as a failure and the journey evaluation ends. A single `<action>` may contain
+multiple expectations.
+Example:
+```<action>Verify that the app is on the Home screen, the Home icon is blue, and the temperature is displayed</action>```
+This `<action>` fails if ANY of the following are false:
+- The app is on the Home screen
+- There is a Home icon, and it is blue
+- A temperature is displayed
+
+## Handling failure 
+When running a journey, evaluate it as a test. Failure is acceptable, and often expected. Proper reporting of failures is the priority.
+
+Keep debugging and troubleshooting to a minimum; assume that tools are showing you the correct output every time. The goal is to determine 
+if the *current* Android app can correctly handle the *current* steps outlined in the journey. Suggestions for bug fixes, clarification, or 
+other improvements should be kept to journey evaluation summary at the end.
+
+## Summarizing
+For each `<action>` you evaluated, output JSON describing the results.
+
+```
+{
+  "journey:", The name of the journey
+  "results:" [
+    {
+      // A string containing the full text of the <action> 
+      "action": "Click the blue button,
+      // "PASSED" if the instruction was evaluated, "FAILED" if the instruction could not be evaluated, or "SKIPPED" if journey evaluation ended early because an instruction failed 
+      "status": "PASSED", 
+      // A list of the ADB commands executed while evaluating the instruction,
+      "commands": [ "adb input swipe 490 200 500 500 500", "adb input tap 45 920" ],  
+      // Failure reasons, feedback, or other useful information 
+      "comment": "The journey step doesn't specify that the button requires scrolling to see", 
+    },
+    {
+      "action": "The home screen is shown", 
+      "status": "FAILED", 
+      "comment": "The settings page was shown",   
+    },
+  ]
+}
+```

--- a/.agents/skills/compose-recomposition-performance/SKILL.md
+++ b/.agents/skills/compose-recomposition-performance/SKILL.md
@@ -1,0 +1,59 @@
+---
+description: Use when investigating Jetpack Compose recomposition performance, skippable/restartable composables, composables.txt or compiler reports, Layout Inspector recomposition counts, back-writing snapshot state across phases, or frame-rate State reads in composition vs layout/draw, and it is not yet clear whether the cause is parameter stability, deferred reads, or cross-phase back-writing.
+metadata:
+    github-path: skills/compose-recomposition-performance
+    github-ref: refs/tags/2026.05.21
+    github-repo: https://github.com/chrisbanes/skills
+    github-tree-sha: 0656964966d23cf6f2eb27bb052d92a80af20b2e
+name: compose-recomposition-performance
+---
+# Compose recomposition performance
+
+Router only — deep fixes live in focused skills below.
+
+## Three axes
+
+1. **Parameter stability / skipping** — can Compose skip this restartable composable; are arguments stable and comparable?
+2. **Where `State` is read** — is frame-rate `State` read during composition vs layout/draw?
+3. **Back-writing across phases** — does a later phase write snapshot state that invalidates an earlier phase? Examples: map/list mutation during composition that re-invalidates the same composition; `onSizeChanged` (layout phase) writing state read by a sibling in composition.
+
+Axes 2 and 3 often overlap (a sibling reading measured size in composition is both a deferred-read violation and a layout → composition back-write). Axis 1 is independent.
+
+## Route here → focused skill
+
+| Primary suspicion | Next skill |
+|---|---|
+| Skipping, unstable params, compiler/`composables.txt` churn | [`compose-stability-diagnostics`](../compose-stability-diagnostics/SKILL.md) |
+| Frame-rate `State` read phase (composition vs layout/draw) | [`compose-state-deferred-reads`](../compose-state-deferred-reads/SKILL.md) |
+| `putAll` / map rebuild / cross-row `height(state)` during composition | [`compose-state-deferred-reads`](../compose-state-deferred-reads/SKILL.md) — § back-writing |
+| Focus-driven side work in composable body | [`compose-side-effects`](../compose-side-effects/SKILL.md) — `snapshotFlow` |
+| Evidence for multiple axes | Apply matching skills in parallel |
+
+## Review order
+
+1. Reproduce one transition (focus move, insertion, scroll) and note which composables recompose.
+2. If counts spike on unchanged lazy items, check back-writing (composition mutations and cross-row measurement) before blaming stability.
+3. If counts climb every frame during scroll/animation, check deferred reads.
+4. If skipping fails despite stable data, check parameter stability and compiler reports.
+5. Re-measure after each fix.
+
+## False leads
+
+These changes often **do not** reduce recomposition count:
+
+| Attempt | Why it fails |
+|---|---|
+| `remember(index) { isFirstRow(index) }` instead of inline `when (index)` | Same inputs; no skipping benefit |
+| Identity cache for read-only derived maps | Can serve stale overlays; `remember(keys)` is enough |
+| `mutableIntStateOf` + layout modifier on **both** measured and sibling rows | Sibling still reads size in composition unless measure-only |
+| Forcing `Exactly(1)` on both rows in focus-move tests | One row often correctly recomposes 0 times |
+| Hoisting without stabilizing lambda captures | New lambda instance each frame still defeats skipping |
+
+## When NOT to apply
+
+- Recomposition tracks real data changes, or the bug is correctness not cost.
+- No profiler / compiler signal suggests a problem.
+
+## Related
+
+- [`compose-state-authoring`](../compose-state-authoring/SKILL.md) — authoring `mutableState*` safely.

--- a/.agents/skills/compose-stability-diagnostics/SKILL.md
+++ b/.agents/skills/compose-stability-diagnostics/SKILL.md
@@ -1,0 +1,173 @@
+---
+description: Use when writing or reviewing Jetpack Compose parameter stability, compiler reports, skippability, unstable UI state classes, collection parameters, or Kotlin 2.0+ strong skipping behavior.
+metadata:
+    github-path: skills/compose-stability-diagnostics
+    github-ref: refs/tags/2026.05.21
+    github-repo: https://github.com/chrisbanes/skills
+    github-tree-sha: 8d59efa332c5c945294f9bb86c2ad3401f63f35b
+name: compose-stability-diagnostics
+---
+# Compose stability diagnostics
+
+## Core principle
+
+Compose performance problems from parameters are about **whether inputs compare cheaply and predictably across recompositions**. With Kotlin 2.0.20+ strong skipping is enabled by default, so unstable parameters no longer automatically make restartable composables non-skippable. That does not make stability irrelevant: unstable parameters are compared by instance identity (`===`), stable parameters by equality (`equals`), and churny instances can still defeat skipping.
+
+First identify the compiler mode you are on, then read reports in that context.
+
+## When to use this skill
+
+- A composable or screen recomposes more than expected and parameter churn is suspected.
+- A UI-state/model class is passed to composables and contains `List`, `Set`, `Map`, ranges, Java time/money types, or third-party types.
+- `composables.txt` / `classes.txt` shows unstable parameters or non-skippable composables.
+- A project uses Kotlin < 2.0.20, disables strong skipping, or has old Compose compiler report guidance.
+
+## 1. Start with strong skipping
+
+On Kotlin 2.0.20+, strong skipping is enabled by default. In that mode:
+
+- Restartable composables are skippable even when parameters are unstable, unless explicitly opted out.
+- Stable parameters compare with `equals`.
+- Unstable parameters compare with instance equality (`===`).
+- Lambdas inside composables are automatically remembered based on captures.
+
+That means the question changes from "is this composable skippable at all?" to "will these parameters compare the way I expect, and are callers creating new unstable instances every frame?"
+
+For older compiler setups or strong skipping disabled, the legacy rule still matters: a restartable composable with unstable parameters may be restartable but not skippable.
+
+## 2. Generate compiler reports
+
+With Kotlin 2.0+ the Compose Compiler is configured through the Kotlin Gradle plugin:
+
+```kotlin
+plugins {
+    alias(libs.plugins.android.application) // or android.library / jvm
+    alias(libs.plugins.kotlin.android)      // or kotlin.multiplatform / kotlin.jvm
+    alias(libs.plugins.compose.compiler)
+}
+
+if (providers.gradleProperty("composeReports").orNull == "true") {
+    composeCompiler {
+        reportsDestination = layout.buildDirectory.dir("compose_compiler")
+        metricsDestination = layout.buildDirectory.dir("compose_compiler")
+    }
+}
+```
+
+Then build the variant whose compiler configuration you care about, for example:
+
+```bash
+./gradlew :app:assembleRelease -PcomposeReports=true
+```
+
+Use release/non-debuggable builds for runtime profiling. Compiler reports are build-time outputs, so the important thing is matching the variant and compiler flags you ship.
+
+Key files:
+
+| File | What it tells you |
+|---|---|
+| `<module>-classes.txt` | Stability of classes and properties |
+| `<module>-composables.txt` | Restartable/skippable status and parameter stability |
+| `<module>-composables.csv` | Same data in sortable form |
+| `<module>-module.json` | Aggregate metrics |
+
+## 3. Fix stability where semantics need it
+
+Pick the lightest fix that makes the type's immutability or equality semantics true.
+
+### Immutable collections
+
+`kotlin.collections.List` is an interface; Compose cannot know the runtime implementation is immutable. Prefer `kotlinx.collections.immutable` at UI-state boundaries:
+
+```kotlin
+// Before: unstable collection interfaces
+data class UiState(val items: List<Item>, val tags: Set<String>)
+
+// After: immutable collection contracts
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableSet
+
+data class UiState(val items: ImmutableList<Item>, val tags: ImmutableSet<String>)
+```
+
+Producers convert once at the boundary with `.toImmutableList()` / `.toImmutableSet()`.
+
+### `@Immutable` / `@Stable`
+
+- Use `@Immutable` when every property is effectively immutable and equality describes all observable state.
+- Use `@Stable` for types whose mutable state is observable by Compose, typically via `MutableState`.
+
+Do not annotate to silence a report. A false stability promise can produce stale UI.
+
+### Third-party immutable types
+
+For types you cannot annotate, use `stabilityConfigurationFiles`:
+
+```kotlin
+composeCompiler {
+    stabilityConfigurationFiles.add(
+        rootProject.layout.projectDirectory.file("compose_stability.conf"),
+    )
+}
+```
+
+```text
+java.math.BigDecimal
+java.math.BigInteger
+java.time.*
+kotlinx.datetime.*
+```
+
+Only list types you are willing to promise are immutable. Do not list mutable types such as `java.util.Date`.
+
+## 4. Stabilize lazy item inputs
+
+Lazy list items recompose when their lambda inputs change identity, even if the visible data is unchanged.
+
+Hoist and remember per-item inputs that are stable for the item's lifetime:
+
+```kotlin
+// ❌ BAD — new lambda instances when parent recomposes
+items(list, key = { it.id }) { item ->
+    RowCard(
+        onClick = { onItemClick(item.id) },
+        isHighlighted = { item.id == selectedId },
+    )
+}
+
+// ✅ GOOD — stable captures for this item instance
+items(list, key = { it.id }) { item ->
+    val onClick = remember(item.id) { { onItemClick(item.id) } }
+    val isHighlighted = remember(item.id, selectedId) { item.id == selectedId }
+    RowCard(onClick = onClick, isHighlighted = isHighlighted)
+}
+```
+
+Also hoist row position metadata (`isFirst`, `isLast`, corner radii) with `remember(index) { … }` when the value depends only on index — but do not expect this alone to fix back-writing or cross-row measurement bugs.
+
+Verify focus moves and insertions with recomposition-count assertions after hoisting.
+
+## Quick reference
+
+| Symptom | Diagnosis | Fix |
+|---|---|---|
+| Kotlin 2.0.20+ but old docs say unstable means non-skippable | Strong skipping changed the default | Check comparison semantics and instance churn instead |
+| `unstable val items: List<Item>` | Interface collection | Use `ImmutableList<Item>` or another true immutable wrapper |
+| `unstable val price: BigDecimal` | External immutable type | Add to stability config |
+| `@Immutable` on a type with mutable internals | False promise | Fix the model or remove the annotation |
+| Composable skips poorly despite strong skipping | New unstable instance each recomposition | Remember, hoist, or make the type stable/equality-based |
+| Lazy items recompose on parent recompose despite unchanged data | New lambda or derived-value instance per parent recompose (§4) | Hoist per-item with `remember(item.id) { … }` |
+| Reports not generated | Compose compiler plugin missing or flag not set | Apply `org.jetbrains.kotlin.plugin.compose` and enable destinations |
+
+## When NOT to apply
+
+- The issue is back-writing across phases or cross-row measurement reads. Use [`compose-state-deferred-reads`](../compose-state-deferred-reads/SKILL.md).
+- The issue is a fast-changing `State` read in composition, such as scroll or animation. Use [`compose-state-deferred-reads`](../compose-state-deferred-reads/SKILL.md).
+- The recomposition count matches real data changes.
+- The bug is wrong data or stale state, not excess work.
+- The code is test-only and readability is more important than report cleanliness.
+
+## Related
+
+- [`compose-state-deferred-reads`](../compose-state-deferred-reads/SKILL.md) - frame-rate state should often be read in layout/draw rather than composition.
+- [`compose-recomposition-performance`](../compose-recomposition-performance/SKILL.md) - entry point when you are not sure which recomposition axis is involved.

--- a/.agents/skills/compose-state-authoring/SKILL.md
+++ b/.agents/skills/compose-state-authoring/SKILL.md
@@ -1,0 +1,186 @@
+---
+description: Use when writing or reviewing Jetpack Compose code with bare local var in a @Composable, remember { mutableStateOf(...) }, mutableStateListOf/mutableStateMapOf, or @ReadOnlyComposable.
+metadata:
+    github-path: skills/compose-state-authoring
+    github-ref: refs/tags/2026.05.21
+    github-repo: https://github.com/chrisbanes/skills
+    github-tree-sha: 64540b69d26b906c66479833dc66c4f917a4e389
+name: compose-state-authoring
+---
+# Compose state authoring
+
+Not every `remember { … }` belongs here. This skill covers **local UI state** (`remember { mutableStateOf(…) }`, `mutableStateListOf` / `mutableStateMapOf`) and **`@ReadOnlyComposable`**. Other remembered APIs live in focused skills:
+
+- **`rememberCoroutineScope` / `rememberUpdatedState`** → [`compose-side-effects`](../compose-side-effects/SKILL.md)
+- **`rememberLazyListState` / `rememberScrollState`** used for frame-rate reads → [`compose-state-deferred-reads`](../compose-state-deferred-reads/SKILL.md)
+- **Focus navigation, focus state, `FocusRequester` ownership, behavior** → [`compose-focus-navigation`](../compose-focus-navigation/SKILL.md)
+
+## Core principle
+
+A `@Composable` is a function the runtime re-runs whenever its inputs change. Writing local state correctly comes down to two questions:
+
+1. **Mutable local state** — does my `var` survive recomposition *and* trigger it? If not, it silently resets on every recompose and writes are invisible.
+2. **What kind of composable is this?** — do I *mutate* composition (place layout nodes, allocate slots, `remember`) or only *read* it? If only read, `@ReadOnlyComposable` lets the runtime skip work.
+
+Get either wrong and the symptoms are subtle: state that vanishes or optimizations that don't apply.
+
+## When to use this skill
+
+You're writing or reviewing Compose code and you see any of these:
+
+- `var x = …` inside a `@Composable fun` or any composable lambda (`Column { var x = … }`)
+- A `@Composable fun` (or `@Composable get()` property accessor) whose body never lays anything out
+- `@ReadOnlyComposable` on a function that calls `Text`, `Box`, `Column`, `remember`, …
+- A composable whose visible state mysteriously resets on rotation, theme change, or recomposition
+
+## 1. `var` in a composable must be State-backed
+
+Recomposition re-executes the composable from the top. A local `var` is *re-initialized* on every pass — last recompose's value is gone, and writing to it doesn't tell the runtime to recompose.
+
+```kotlin
+// ❌ BAD — counter resets on every recomposition; clicks never update the UI
+@Composable
+fun Counter() {
+    var count = 0
+    Button(onClick = { count++ }) { Text("$count") }
+}
+
+// ❌ ALSO BAD — same rule applies inside composable content lambdas
+@Composable
+fun Wrapper() {
+    Row {
+        var count = 0         // Row's content lambda is @Composable too
+        // …
+    }
+}
+```
+
+```kotlin
+// ✅ GOOD — `remember` survives recomposition, `mutableStateOf` triggers it
+@Composable
+fun Counter() {
+    var count by remember { mutableStateOf(0) }
+    Button(onClick = { count++ }) { Text("$count") }
+}
+```
+
+Two pieces and both matter:
+
+- `remember { … }` — *survives recomposition*. Without it the value is re-created each time.
+- `mutableStateOf(…)` — *triggers recomposition*. Without it, mutations are invisible to the runtime.
+
+For collections, prefer `mutableStateListOf` / `mutableStateMapOf` (also `remember`-ed). They emit Snapshot reads on every read and Snapshot writes on every mutation. A `remember { mutableStateOf(mutableListOf<X>()) }` followed by `list.add(x)` will *not* recompose, because `MutableList.add` doesn't go through the State setter — you'd have to replace the value (`state = state + x`).
+
+### Back-writing snapshot state during composition
+
+**Back-writing** means writing observable state in a phase that triggers invalidation of an earlier (or the current) phase. Mutating `mutableState*` from the composable body back-writes into the same composition pass and schedules another. Do not rebuild derived data this way:
+
+```kotlin
+// ❌ BAD — clear + putAll on every composition
+val merged = remember { mutableStateMapOf<Key, ViewState>() }
+merged.clear()
+merged.putAll(parent)
+merged.putAll(overlay)
+
+// ✅ GOOD — immutable snapshot remembered from inputs
+val merged = remember(parent, overlay) {
+    if (overlay.isEmpty()) parent else parent + overlay
+}
+```
+
+If the result is read-only for the current inputs, `remember(keys) { … }` is enough. See [`compose-state-deferred-reads`](../compose-state-deferred-reads/SKILL.md) for cross-row measurement and measure-phase fixes.
+
+### When this rule does NOT apply
+
+- **Inside `remember { … }`'s producer block.** That runs once per key change, not on every recompose. A local `var` there is fine: `val builder = remember { mutableListOf<X>().apply { var n = 0; … } }`.
+- **In non-`@Composable` lambdas passed *out* of a composable.** `onClick = { var a = 0; … }` is a plain `() -> Unit`. Local vars there are normal Kotlin.
+- **In plain (non-`@Composable`) helper functions.** Only composable scopes are affected.
+
+## 2. The `@ReadOnlyComposable` contract
+
+`@ReadOnlyComposable` declares that a composable *only reads* composition state — no `Text`, no `Box`, no `remember`, no layout nodes, no positional slots. The runtime can then skip allocating a group for the call, which matters for fast accessor-style composables (`MaterialTheme.colorScheme`, `LocalDensity.current`, design-system token accessors).
+
+The contract is **bidirectional**:
+
+- **Add `@ReadOnlyComposable`** when every composable call your body makes is itself `@ReadOnlyComposable` (or there are no composable calls at all — for example a function that only reads `LocalFoo.current` and returns a value).
+- **Don't add it** if you call any non-read-only composable. The optimization assumes you don't participate in composition; violating that produces incorrect recomposition behaviour for callers.
+
+```kotlin
+// ✅ GOOD — only reads composition locals, no layout, no remember
+@Composable
+@ReadOnlyComposable
+fun appSpacing(): Dp = LocalDimensions.current.spacing
+
+// ✅ GOOD — composable property getter; same rule
+val accent: Color
+    @Composable @ReadOnlyComposable
+    get() = MaterialTheme.colorScheme.tertiary
+```
+
+```kotlin
+// ❌ BAD — annotated read-only but lays out a Box; contract violated
+@Composable
+@ReadOnlyComposable
+fun Header(): Int {
+    Box {}                  // ← non-read-only composable call
+    return 42
+}
+
+// ❌ BAD — calls a normal composable from a read-only one
+@Composable
+@ReadOnlyComposable
+fun computed(): Int = nonReadOnlyHelper()
+```
+
+### Heuristic for "should I add it"
+
+If the body contains any of these, **do not** add `@ReadOnlyComposable`:
+
+- A layout call: `Box`, `Column`, `Row`, `LazyColumn`, `Text`, anything from `androidx.compose.foundation.layout` or `androidx.compose.material*`.
+- A side-effect call: `LaunchedEffect`, `DisposableEffect`, `SideEffect`, `produceState`.
+- `remember { … }` — positional memoization is composition state.
+- A `@Composable` lambda invocation (`content()`).
+- An invocation of a non-`@ReadOnlyComposable` composable function.
+
+If the body is only reading `Local*.current`, calling other `@ReadOnlyComposable` functions, or doing pure computation, **add** it.
+
+### When this rule does NOT apply
+
+- **`override fun` declarations.** The annotation is part of the contract; if the base isn't `@ReadOnlyComposable`, you can't make an override one. Refactor the base, or accept the override pays the group-creation cost.
+- **Abstract declarations.** No body to check.
+
+## Related: side effects live in their own skill
+
+If a composable needs `LaunchedEffect`, `DisposableEffect`, `SideEffect`, `rememberCoroutineScope`, `rememberUpdatedState`, `snapshotFlow`, snackbar/navigation handling, analytics, or Flow collection, use [`compose-side-effects`](../compose-side-effects/SKILL.md).
+
+Focus splits by question: **navigation, focus state, `FocusRequester` ownership, behavior** → [`compose-focus-navigation`](../compose-focus-navigation/SKILL.md); **when** to call imperative `requestFocus` (effect timing, lifecycle, keys, API choice) → [`compose-side-effects`](../compose-side-effects/SKILL.md).
+
+This skill is about authoring Compose state correctly. `rememberUpdatedState` is effect capture state, not a general replacement for `remember { mutableStateOf(...) }`. Side effects have separate lifecycle and keying rules, and keeping them in one focused skill avoids two sources of truth.
+
+## Quick reference
+
+| Symptom | Diagnosis | Fix |
+|---|---|---|
+| `var x = …` inside `@Composable fun` body | Not recomposition-safe (§1) | `var x by remember { mutableStateOf(…) }` |
+| `var x = …` inside `Column { … }` / `Row { … }` content lambda | Same — content lambdas are `@Composable` (§1) | Same fix |
+| `remember { mutableStateOf(list) }` then `.add(x)` not recomposing | Mutation bypasses State setter | Use `mutableStateListOf`, or replace the value: `state = state + x` |
+| `stateMap.clear(); stateMap.putAll(...)` in composable body | Back-writing composition → composition | `remember(keys) { derivedSnapshot }` |
+| `@Composable fun` with no `Text`/`Box`/`remember`/effect calls | Could be `@ReadOnlyComposable` (§2) | Add `@ReadOnlyComposable` above `@Composable` |
+| `@ReadOnlyComposable` function that calls `Box {}` / `Column {}` / a normal composable | Contract violation (§2) | Remove `@ReadOnlyComposable` |
+
+## When NOT to apply
+
+- **Tests** with `composeTestRule.setContent { … }` follow the same rules — they're production composables.
+- **`produceState`** has its own producer block that runs in a coroutine; you don't need `LaunchedEffect` *inside* it.
+- **`derivedStateOf`** has its own concerns around stability and equality — out of scope here; it's about *preventing* recomposition, not authoring state.
+- **`override`s** of read-only-composable declarations: the annotation is fixed by the base; you can't add or remove it locally.
+
+## Red flags during review
+
+| Thought | Reality |
+|---|---|
+| "It's a small composable, the bare `var` is fine" | Recomposition can fire at any time. The reset is non-deterministic by design — and a single bug report later. |
+| "I'll add `@ReadOnlyComposable` because the function looks simple" | "Simple" isn't the criterion. "Makes only read-only calls" is. |
+| "I always reach for `LaunchedEffect` because it's the one I know" | Use `compose-side-effects`; effect API choice depends on lifecycle and keys. |
+| "I'll just `.add()` to the remembered list" | A `mutableStateOf(List)` doesn't observe internal mutation — use `mutableStateListOf` or replace the value. |
+| "The override needs `@ReadOnlyComposable` to match what it does" | If the base isn't `@ReadOnlyComposable`, you can't add it to an override. Refactor the base instead. |

--- a/.agents/skills/compose-state-deferred-reads/SKILL.md
+++ b/.agents/skills/compose-state-deferred-reads/SKILL.md
@@ -1,0 +1,211 @@
+---
+description: Use when Jetpack Compose code reads scroll, animation, gesture, or other frame-rate State in composition, passes changing values across composable boundaries, uses value-form layout/draw modifiers, or back-writes observable state from a later phase into one that's already run.
+metadata:
+    github-path: skills/compose-state-deferred-reads
+    github-ref: refs/tags/2026.05.21
+    github-repo: https://github.com/chrisbanes/skills
+    github-tree-sha: 27c4072305c4412f7468f84cf9c6534b68652cad
+name: compose-state-deferred-reads
+---
+# Compose state deferred reads
+
+## Core principle
+
+State reads invalidate the phase that reads them. If a `State<T>` is read in a composable body, changes invalidate composition. If it is read in layout or draw, changes can invalidate only layout or draw. Frame-rate state such as scroll offsets, animations, and drag positions usually belongs in layout/draw, not composition.
+
+**Back-writing** is the symmetric failure mode: writing observable state from a phase that triggers invalidation of an earlier phase. Compose phases run composition → layout → draw. Writing snapshot-backed state from layout or draw to state read in composition invalidates composition; writing during composition to state read earlier in the same composition does the same. Both schedule extra work — often cascading into sibling lazy items.
+
+The fix is structural: keep the `State<T>` or a provider lambda and read the value inside a layout/draw callback; capture measurements in callbacks and apply them in the measure phase, not by reading measurement state in sibling composable bodies.
+
+## When to use this skill
+
+- `val x by animate*AsState(...)` is passed to `Modifier.offset(x = ...)`, `Modifier.size(...)`, `Modifier.graphicsLayer(...)`, or another value-form modifier.
+- `LazyListState.firstVisibleItemScrollOffset`, `ScrollState.value`, `Animatable.value`, or gesture state is read in a composable body.
+- A composable takes `scrollOffset: Int`, `progress: Float`, `dragOffset: Offset`, or similar frame-rate values.
+- Recomposition counters climb during scroll, animation, or gestures even when data is stable.
+- A composable body calls `stateMap[key] = …`, `list.addAll(…)`, or similar on every recomposition (back-writing composition → composition).
+- One lazy item captures size with `onSizeChanged` / `onGloballyPositioned` and a sibling reads that height in composition (`Modifier.height(state.dp)`) — back-writing layout → composition.
+
+## 0. Back-writing
+
+**Back-writing** = writing observable state in one phase that triggers invalidation of an earlier (or the current) phase. Compose runs composition → layout → draw, so:
+
+- Writing snapshot state during composition that's read in the same composition.
+- Writing snapshot state during layout (e.g. from `Modifier.layout`, `onSizeChanged`, `onGloballyPositioned`) that's read during composition.
+- Writing snapshot state during draw that's read during composition or layout.
+
+In all cases the writer schedules extra invalidation passes — often cascading into sibling lazy items.
+
+Do not write to `mutableStateOf`, `mutableStateListOf`, `mutableStateMapOf`, or other snapshot-backed state from the composable body on every pass:
+
+```kotlin
+// ❌ BAD — mutates observable map during composition; siblings recompose repeatedly
+@Composable
+fun MergeOverlay(parent: Map<Key, ViewState>, overlay: Map<Key, ViewState>): Map<Key, ViewState> {
+    val merged = remember { mutableStateMapOf<Key, ViewState>() }
+    merged.clear()
+    merged.putAll(parent)
+    merged.putAll(overlay)   // back-writing composition → composition
+    return merged
+}
+
+// ✅ GOOD — read-only merge; no composition-time writes
+@Composable
+fun MergeOverlay(parent: Map<Key, ViewState>, overlay: Map<Key, ViewState>): Map<Key, ViewState> =
+    remember(parent, overlay) {
+        if (overlay.isEmpty()) parent else parent + overlay
+    }
+```
+
+Prefer `remember(keys) { … }` for derived read-only snapshots. Reserve `mutableState*` writes for event callbacks (`onClick`) or effects — not for rebuilding derived data on every composition.
+
+Callbacks like `onSizeChanged` write *during layout*. That is only safe if no earlier phase reads the resulting state — see cross-row measurement below.
+
+### Cross-row measurement (layout → composition back-write)
+
+When row A measures and row B must match A's height, do not read A's captured size in B's composable body. `onSizeChanged` writes during layout; if B reads it in composition, layout has just back-written into composition:
+
+```kotlin
+var anchorHeightPx by remember { mutableIntStateOf(0) }
+
+// ❌ BAD — B reads measurement state in composition; insertion/focus can double-recompose B
+RowA(Modifier.onSizeChanged { anchorHeightPx = it.height })
+RowB(Modifier.height(with(LocalDensity.current) { anchorHeightPx.toDp() }))  // composition read
+
+// ✅ GOOD — capture on A; apply on B in measure phase only
+RowA(Modifier.onSizeChanged { if (it.height != anchorHeightPx) anchorHeightPx = it.height })
+RowB(
+    Modifier.decorateMeasureConstraints { incoming ->
+        if (anchorHeightPx > 0) incoming.copy(minHeight = anchorHeightPx, maxHeight = anchorHeightPx)
+        else incoming
+    },
+)
+```
+
+`decorateMeasureConstraints` is a small layout helper (see [`compose-modifier-and-layout-style`](../compose-modifier-and-layout-style/SKILL.md)). While height is unknown, siblings use a fixed fallback in composition; once known, only layout invalidates — not an extra composition cascade.
+
+## 1. Prefer block-form modifiers
+
+Several modifiers have value forms and block forms. The value form receives values already read in composition; the block form can read during layout or draw.
+
+```kotlin
+// Before: animated value read in composition by the `by` delegate
+@Composable
+fun SelectionPill(selectedIndex: Int) {
+    val offsetX by animateDpAsState(120.dp * selectedIndex)
+    Box(Modifier.offset(x = offsetX))
+}
+
+// After: State is kept, value is read in the layout-phase offset block
+@Composable
+fun SelectionPill(selectedIndex: Int) {
+    val offsetX = animateDpAsState(120.dp * selectedIndex)
+    Box(
+        Modifier.offset {
+            IntOffset(offsetX.value.roundToPx(), 0)
+        },
+    )
+}
+```
+
+Common replacements:
+
+| Composition read | Deferred read |
+|---|---|
+| `Modifier.offset(x = animatedX)` | `Modifier.offset { IntOffset(animatedX.value.roundToPx(), 0) }` |
+| `Modifier.graphicsLayer(translationY = y)` | `Modifier.graphicsLayer { translationY = yProvider() }` |
+| `val radius by animateFloatAsState(...); drawBehind { drawCircle(radius = radius) }` | `val radius = animateFloatAsState(...); drawBehind { drawCircle(radius = radius.value) }` |
+
+The `drawBehind` block is already draw-phase; the important part is that the `State.value` read also happens inside that block.
+
+## 2. Pass providers across composable boundaries
+
+If the fast-changing value would cross a composable boundary, pass a provider lambda instead of a snapshot value:
+
+```kotlin
+// Before: HomeScreen reads scroll offset in composition and passes the value down
+@Composable
+fun HomeScreen() {
+    val listState = rememberLazyListState()
+    LazyColumn(state = listState) {
+        item { HeroImage(scrollOffset = listState.firstVisibleItemScrollOffset) }
+    }
+}
+
+@Composable
+fun HeroImage(scrollOffset: Int, modifier: Modifier = Modifier) {
+    AsyncImage(
+        model = "...",
+        modifier = modifier.graphicsLayer(translationY = -scrollOffset / 2f),
+    )
+}
+
+// After: the only read happens inside graphicsLayer
+@Composable
+fun HomeScreen() {
+    val listState = rememberLazyListState()
+    LazyColumn(state = listState) {
+        item {
+            HeroImage(
+                scrollOffsetProvider = {
+                    if (listState.firstVisibleItemIndex == 0) {
+                        listState.firstVisibleItemScrollOffset
+                    } else {
+                        0
+                    }
+                },
+            )
+        }
+    }
+}
+
+@Composable
+fun HeroImage(scrollOffsetProvider: () -> Int, modifier: Modifier = Modifier) {
+    AsyncImage(
+        model = "...",
+        modifier = modifier.graphicsLayer {
+            translationY = -scrollOffsetProvider() / 2f
+        },
+    )
+}
+```
+
+Suffix provider parameters with `Provider` when that clarifies the deferred-read contract.
+
+## 3. Other layout/draw read sites
+
+State reads can also be deferred inside:
+
+- `Modifier.layout { measurable, constraints -> ... }`
+- Custom `Alignment.align(...)`
+- `drawWithContent`, `drawBehind`, and other draw modifiers
+- Block-form layer/layout modifiers such as `graphicsLayer { ... }` and `offset { ... }`
+
+Use these when the state changes where something is placed or painted. If the state decides *which composables exist*, it belongs in composition.
+
+## Quick reference
+
+| Symptom | Diagnosis | Fix |
+|---|---|---|
+| `val x by animateFloatAsState(...)` then `Modifier.offset(...)` | `by` reads in composition | Keep `State<Float>` and read `.value` in `offset {}` |
+| `Modifier.graphicsLayer(translationY = animatedY)` | Property-argument form uses composition values | Use `graphicsLayer { translationY = ... }` |
+| `Child(scrollOffset = listState.firstVisibleItemScrollOffset)` | Fast-changing value crosses boundary | `Child(scrollOffsetProvider = { ... })` |
+| Draw block still recomposes every frame | Value was read before draw block | Move the `State.value` read inside the draw block |
+| State chooses between different UI branches | Composition decision | Keep the read in composition |
+| `mergedMap.putAll(overlay)` in composable body | Back-writing composition → composition | `remember(parent, overlay) { parent + overlay }` |
+| Sibling `Modifier.height(measuredPx.toDp())` | Back-writing layout → composition | Measure-phase constraint decoration |
+| Identity cache for read-only merge | Stale overlay risk | `remember(keys)` on immutable result |
+
+## When NOT to apply
+
+- The state controls which composables are emitted.
+- The animation is one-shot, cheap, and clarity wins.
+- You are writing tests where direct value assertions are simpler.
+- Runtime evidence shows recomposition is not the bottleneck.
+
+## Related
+
+- [`compose-state-authoring`](../compose-state-authoring/SKILL.md) — when `mutableState*` belongs in composition vs callbacks.
+- [`compose-state-holder-ui-split`](../compose-state-holder-ui-split/SKILL.md) — where state-holder vs plain UI split applies when passing providers/lambdas across boundaries.
+- [`compose-stability-diagnostics`](../compose-stability-diagnostics/SKILL.md) — parameter stability and compiler reports.
+- [`compose-modifier-and-layout-style`](../compose-modifier-and-layout-style/SKILL.md) — measure-phase constraint decoration helper.

--- a/.agents/skills/compose-state-hoisting/SKILL.md
+++ b/.agents/skills/compose-state-hoisting/SKILL.md
@@ -1,0 +1,139 @@
+---
+description: 'Use when deciding where Jetpack Compose UI element state or UI logic should live: local remember state, hoisted composable parameters, a plain state holder class, or a screen-level ViewModel/component.'
+metadata:
+    github-path: skills/compose-state-hoisting
+    github-ref: refs/tags/2026.05.21
+    github-repo: https://github.com/chrisbanes/skills
+    github-tree-sha: f23b87bd198c6df2918add47bdedcf203ddd6284
+name: compose-state-hoisting
+---
+# Compose state hoisting
+
+## Core principle
+
+Hoist state only as far as the logic needs it. Keep simple UI element state local, move shared UI element state to the lowest common composable owner, extract a plain state holder when UI-only behavior becomes a concept, and use a screen state holder when business logic or app data is involved.
+
+## Decision guide
+
+| Situation | Owner |
+|---|---|
+| One composable reads/writes simple state | Keep local with `remember` / `rememberSaveable` |
+| Sibling or parent composables need to read/write it | Hoist state and events to their lowest common composable ancestor |
+| Related UI element state plus UI logic is making a composable hard to read, preview, or test | Extract a plain state holder class remembered in composition |
+| Repository calls, persistence, business rules, or screen UI state production are involved | Use a screen-level state holder such as a `ViewModel` or component |
+
+UI element state includes things like expansion, sheet visibility, scroll position, focus, text field editing state, selection, and animation/interaction state. Screen UI state is app data prepared for display.
+
+If UI element state is an input to business logic, it may need to live in the screen state holder too. For example, text used to query repository-backed suggestions belongs with the state holder that produces those suggestions.
+
+## Plain state holder trigger
+
+Extract a plain state holder when several of these are true:
+
+- Multiple related `remember` values are coordinated by the same callbacks.
+- Scroll, focus, text, selection, or sheet state needs named operations such as `clear`, `submit`, `jumpToTop`, or `openFilters`.
+- Derived UI flags are scattered through the composable.
+- Child composables receive mechanics they do not conceptually own.
+- Previews or tests must drive a long sequence of UI details to check one behavior.
+- Helper functions need many state parameters just to keep the composable readable.
+
+Do not extract for one boolean, one text field, or trivial show/hide logic. Ceremony is not separation of concerns.
+
+## Pattern
+
+Use a plain class for UI element state and UI logic, plus a `remember...State` function for composition-owned objects:
+
+```kotlin
+@Stable
+class ProductSearchState(
+    query: String,
+    private val listState: LazyListState,
+    private val focusRequester: FocusRequester,
+) {
+    var query by mutableStateOf(query)
+        private set
+
+    var filtersOpen by mutableStateOf(false)
+        private set
+
+    val canClear: Boolean
+        get() = query.isNotEmpty()
+
+    fun updateQuery(value: String) {
+        query = value
+    }
+
+    fun clear() {
+        query = ""
+        focusRequester.requestFocus()
+    }
+
+    suspend fun jumpToTop() {
+        listState.animateScrollToItem(0)
+    }
+}
+
+@Composable
+fun rememberProductSearchState(
+    initialQuery: String = "",
+    listState: LazyListState = rememberLazyListState(),
+    focusRequester: FocusRequester = remember { FocusRequester() },
+): ProductSearchState {
+    return remember(listState, focusRequester) {
+        ProductSearchState(initialQuery, listState, focusRequester)
+    }
+}
+```
+
+The composable renders from the state holder and calls intent-style methods. If a parent needs to coordinate the same UI behavior, accept the state holder as a parameter with a default:
+
+```kotlin
+@Composable
+fun ProductSearchPanel(
+    state: ProductSearchState = rememberProductSearchState(),
+    modifier: Modifier = Modifier,
+) {
+    val scope = rememberCoroutineScope()
+
+    SearchField(
+        query = state.query,
+        onQueryChange = state::updateQuery,
+        onClear = state::clear,
+    )
+
+    JumpToTopButton(onClick = {
+        scope.launch { state.jumpToTop() }
+    })
+}
+```
+
+## Composition ownership
+
+Plain state holders created with `remember` follow the composable lifecycle. This makes them a good home for Compose UI objects such as `LazyListState`, `FocusRequester`, `PagerState`, `DrawerState`, and `TextFieldState`.
+
+Keep suspend UI operations that require a frame clock, such as scroll or drawer animations, in a composition-scoped coroutine (`rememberCoroutineScope`, `LaunchedEffect`, or another composition-owned scope). Do not move those calls to `viewModelScope`.
+
+## Saving state
+
+Use `rememberSaveable` or a custom `Saver` only for values that should survive Activity or process recreation, such as a query string, selected filter IDs, or a current tab key.
+
+Do not try to save runtime objects like `LazyListState`, `FocusRequester`, coroutine scopes, or callbacks directly. Save the minimal serializable values needed to rebuild behavior.
+
+## Common mistakes
+
+| Mistake | Fix |
+|---|---|
+| Hoisting every local state value to a parent "just in case" | Hoist to the lowest owner that actually reads or writes it |
+| Extracting a plain state holder for one boolean | Keep simple private UI state local |
+| Putting repository calls or product rules in a Compose state holder | Move that logic to a screen state holder such as a `ViewModel` or component |
+| Keeping text or selection local when it drives repository-backed screen state | Move that input to the screen state holder with the business logic |
+| Passing a state holder deep into unrelated children | Pass plain values and callbacks unless the child truly coordinates the holder's behavior |
+| Treating the holder as a dumping ground for a whole screen | Split by cohesive UI behavior, such as search input, sheet coordination, or list controls |
+| Calling animation suspend functions from `viewModelScope` | Use a composition-scoped coroutine |
+
+## Related
+
+- [`compose-state-authoring`](../compose-state-authoring/SKILL.md) — correct local `remember` and mutable state authoring.
+- [`compose-state-holder-ui-split`](../compose-state-holder-ui-split/SKILL.md) — split screen state-holder wiring from plain state-driven UI rendering.
+- [`compose-side-effects`](../compose-side-effects/SKILL.md) — choose effect APIs and composition-scoped coroutine boundaries.
+- [`compose-focus-navigation`](../compose-focus-navigation/SKILL.md) — focus state, requesters, and keyboard/D-pad behavior.

--- a/.agents/skills/compose-state-holder-ui-split/SKILL.md
+++ b/.agents/skills/compose-state-holder-ui-split/SKILL.md
@@ -1,0 +1,160 @@
+---
+description: Use when a Jetpack Compose screen-level composable takes a ViewModel/component/controller, collects state or effects, handles navigation/snackbars, or wires callbacks while also rendering layout.
+metadata:
+    github-path: skills/compose-state-holder-ui-split
+    github-ref: refs/tags/2026.05.21
+    github-repo: https://github.com/chrisbanes/skills
+    github-tree-sha: dce6f409de99032b1c625611675ce05f9497682b
+name: compose-state-holder-ui-split
+---
+# Compose: state holder/UI split
+
+## Core principle
+
+Separate state-holder wiring from UI rendering. The state-holder composable talks to ViewModels, components, flows, navigation, and side effects. The UI composable takes plain immutable UI state plus callbacks and describes layout.
+
+This keeps screens previewable, testable, and easier to reuse across Android, Desktop, TV, and KMP/CMP targets.
+
+## When to use this skill
+
+Use this when a Compose screen:
+
+- Takes a ViewModel, component, controller, navigator, repository, or service directly.
+- Collects app/business state or side effects in the same function that lays out most UI.
+- Passes a whole state holder into child composables instead of explicit state and callbacks.
+- Is hard to preview because it needs dependency injection, navigation, lifecycle, or fake services.
+- Has UI tests that must construct a full app stack to verify a simple layout branch.
+
+## The pattern
+
+Use a small public state-holder composable:
+
+```kotlin
+@Composable
+fun ProfileScreen(component: ProfileComponent, modifier: Modifier = Modifier) {
+    val state by component.state.collectAsStateWithLifecycle()
+
+    ProfileScreen(
+        state = state,
+        onNameChange = component::onNameChange,
+        onSaveClick = component::save,
+        onBackClick = component::back,
+        modifier = modifier,
+    )
+}
+```
+
+Then put UI in a plain composable that knows nothing about the state holder:
+
+```kotlin
+@Composable
+fun ProfileScreen(
+    state: ProfileUiState,
+    onNameChange: (String) -> Unit,
+    onSaveClick: () -> Unit,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    ProfileContent(
+        name = state.name,
+        isSaving = state.isSaving,
+        canSave = state.canSave,
+        onNameChange = onNameChange,
+        onSaveClick = onSaveClick,
+        onBackClick = onBackClick,
+        modifier = modifier,
+    )
+}
+```
+
+Private content functions can break up layout:
+
+```kotlin
+@Composable
+private fun ProfileContent(
+    name: String,
+    isSaving: Boolean,
+    canSave: Boolean,
+    onNameChange: (String) -> Unit,
+    onSaveClick: () -> Unit,
+    onBackClick: () -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    // Layout only.
+}
+```
+
+## Rules of thumb
+
+| Concern | State-holder composable | UI composable |
+|---|---|---|
+| Collect ViewModel/component state | Yes | No |
+| Collect one-shot effects | Yes, or a tiny sibling effect handler | Usually no |
+| Hold dependency-injected objects | Yes | No |
+| Accept immutable UI state | Usually passes it through | Yes |
+| Accept lambdas for user events | Wires them | Calls them |
+| Own layout, modifiers, semantics, test tags | No/minimal | Yes |
+| Own UI-local state like scroll, focus, text input, animation, interaction | Sometimes seeds it | Yes |
+| Preview/screenshot friendly | Not necessarily | Yes |
+
+The "no collection in UI composables" rule is about app/business state and side-effect streams. Plain UI composables can still own UI-local framework state: `rememberScrollState`, `rememberLazyListState`, `FocusRequester`, focus state, animation state, `TextFieldState`, `MutableInteractionSource.collectIsPressedAsState()`, and similar behavior that belongs to the rendered widget.
+
+If that UI-local state grows into coordinated behavior with multiple related fields and operations, use [`compose-state-hoisting`](../compose-state-hoisting/SKILL.md) to decide whether it should become a plain state holder class remembered in composition.
+
+## What to pass
+
+Pass the smallest useful UI contract:
+
+- Prefer a dedicated `UiState`/`State` object over many unrelated primitives when the screen has real state.
+- Prefer explicit lambdas (`onRetryClick`, `onItemSelected`) over passing a whole component.
+- Keep domain models out of the UI composable if they force business rules into UI. Map to UI models when the UI needs a different shape.
+- Keep navigation as callbacks. The UI composable says "user clicked back", not "navigate to route X".
+- Frame-rate or UI-local values that should not force whole-tree recomposition when they change: prefer provider lambdas and deferred reads per [`compose-state-deferred-reads`](../compose-state-deferred-reads/SKILL.md).
+
+## Side effects
+
+[`compose-side-effects`](../compose-side-effects/SKILL.md) covers effect APIs (`LaunchedEffect`, `DisposableEffect`, `SideEffect`), keys, cleanup, and `rememberUpdatedState`.
+
+Handle effects near the state holder, where the effect source and imperative target are both available:
+
+```kotlin
+@Composable
+fun ProfileScreen(component: ProfileComponent, snackbarHostState: SnackbarHostState) {
+    val state by component.state.collectAsStateWithLifecycle()
+
+    LaunchedEffect(component) {
+        component.effects.collect { effect ->
+            when (effect) {
+                ProfileEffect.Saved -> snackbarHostState.showSnackbar("Saved")
+            }
+        }
+    }
+
+    ProfileScreen(state = state, onSaveClick = component::save)
+}
+```
+
+If effect handling grows, extract `ProfileEffects(component, snackbarHostState)` rather than pushing the component into the UI composable.
+
+## Common mistakes
+
+| Mistake | Why it hurts | Fix |
+|---|---|---|
+| `fun Screen(viewModel: MyViewModel)` contains all layout | Hard to preview/test without Android lifecycle and DI | Add a plain UI overload that takes `state` and callbacks |
+| Child composables take `component` | Dependencies leak through the tree | Pass only the state/callbacks that child needs |
+| UI composable launches navigation | UI becomes coupled to app routing | Expose `onBackClick`, `onItemClick`, etc. |
+| UI composable collects app/business flows | Collection lifecycle is hidden in layout | Collect near the state holder and pass values down |
+| UI-local state is hoisted into the state holder for no reason | State holder starts owning layout mechanics | Keep scroll/focus/animation/text-field interaction state in the UI composable when it is only UI behavior |
+| Every tiny composable gets a state-holder overload | Too much ceremony | Split at screen/section boundaries, not every `Row` |
+
+## When NOT to apply
+
+- Tiny one-off composables that already take plain values and callbacks.
+- Design-system primitives such as `Button`, `Card`, or `ListItem`; those should expose slots and modifiers, not state holders.
+- Cases where the state-holder composable would only forward one primitive and add no isolation.
+
+## Related
+
+- [`compose-ui-testing-patterns`](../compose-ui-testing-patterns/SKILL.md) — testing plain state-driven UI composables without the full app graph.
+- [`compose-state-hoisting`](../compose-state-hoisting/SKILL.md) — deciding where UI element state and UI logic should live, including plain state holder classes.
+- [`kotlin-multiplatform-expect-actual`](../kotlin-multiplatform-expect-actual/SKILL.md) — platform services, native views, and expect/interface boundaries when shared UI meets platform-specific leaves.

--- a/.agents/skills/compose-ui-testing-patterns/SKILL.md
+++ b/.agents/skills/compose-ui-testing-patterns/SKILL.md
@@ -1,0 +1,182 @@
+---
+description: Use when writing or reviewing Jetpack Compose UI tests, screenshot tests, previews, semantics assertions, fake image loading, keyboard input, focus assertions, interaction state (hover/pressed/focused), or tests for plain state-driven UI composables.
+metadata:
+    github-path: skills/compose-ui-testing-patterns
+    github-ref: refs/tags/2026.05.21
+    github-repo: https://github.com/chrisbanes/skills
+    github-tree-sha: d424a42d2e7fec61d82f24e47b0be6fb7630ae5d
+name: compose-ui-testing-patterns
+---
+# Compose: UI testing patterns
+
+## Core principle
+
+Test the smallest UI contract that proves the behavior. Prefer plain state-driven UI tests with callbacks. Add integration only when lifecycle, navigation, DI, or platform behavior is the thing under test.
+
+## Test target choice
+
+| What you need to prove | Test shape |
+|---|---|
+| Text, button, loading/error branch, conditional content | Plain UI Compose test |
+| Callback wiring from click/input | Plain UI Compose test |
+| Focus navigation or keyboard behavior | Compose test with key input |
+| Visual layout, clipping, elevation, typography, image composition | Screenshot test |
+| State holder updates UI correctly | State holder/unit test plus one wiring smoke test |
+| Hover, pressed, focused, dragged interaction state | Plain UI test with MutableInteractionSource |
+| Navigation, lifecycle, DI integration | Integration test |
+
+## Prefer plain UI tests
+
+If the screen has a state holder/UI split, test the plain UI composable:
+
+```kotlin
+composeTestRule.setContent {
+    ProfileScreen(
+        state = ProfileUiState(name = "Ada", canSave = true),
+        onNameChange = {},
+        onSaveClick = { saved = true },
+        onBackClick = {},
+    )
+}
+
+composeTestRule.onNodeWithText("Ada").assertIsDisplayed()
+composeTestRule.onNodeWithText("Save").performClick()
+
+assertThat(saved).isTrue()
+```
+
+This avoids constructing ViewModels, components, repositories, navigation, and dependency graphs for layout behavior.
+
+## Semantics first
+
+Assert semantics when behavior is semantic:
+
+- Text exists: `onNodeWithText`.
+- Button is enabled/disabled: `assertIsEnabled`, `assertIsNotEnabled`.
+- Content is selected/focused/toggled: use semantics assertions.
+- Content is absent: `assertDoesNotExist`.
+
+Use test tags for nodes that have no stable user-visible text or where multiple nodes share text. Do not use tags as the first choice for all assertions; user-visible semantics are usually stronger.
+
+## Callback testing
+
+Use simple counters or captured values:
+
+```kotlin
+var selectedId: String? = null
+
+composeTestRule.setContent {
+    ItemList(
+        items = listOf(ItemUi("movie-1", "Movie")),
+        onItemClick = { selectedId = it },
+    )
+}
+
+composeTestRule.onNodeWithText("Movie").performClick()
+
+assertThat(selectedId).isEqualTo("movie-1")
+```
+
+For plain captured callback values, a direct assertion after the action is usually enough. Use `runOnIdle` when the assertion needs Compose to finish applying snapshot state, recomposition, or queued UI work before reading the result.
+
+## Interaction state with MutableInteractionSource
+
+When a composable's appearance or behavior depends on interaction state (hover, focus, press, drag), inject a `MutableInteractionSource` and emit the desired state directly. Do not try to simulate pointer/mouse events to trigger interaction states — that approach is fragile, environment-dependent, and produces flaky tests.
+
+```kotlin
+val interactionSource = MutableInteractionSource()
+
+composeTestRule.setContent {
+    OutlinedButton(
+        onClick = {},
+        interactionSource = interactionSource,
+    )
+}
+
+// Assert default (un-hovered) state
+composeTestRule.onNodeWithText("OutlinedButton").assertIsDisplayed()
+
+// Emit hover — interactionSource.emit is a suspend function,
+// so call it from a test coroutine scope.
+TestScope().launch {
+    interactionSource.emit(HoverInteraction.Enter())
+}
+
+composeTestRule.waitForIdle()
+
+// Assert the visual/semantic change that hover produces
+// (e.g., border color, elevation, or capture for screenshot test)
+composeTestRule.onNodeWithText("OutlinedButton").assertIsDisplayed()
+```
+
+The same pattern works for `PressInteraction.Press` / `Release` / `Cancel`, `FocusInteraction.Focus` / `Unfocus`, and `DragInteraction.Start` / `Stop` / `Cancel`. Emit the entry interaction, `waitForIdle`, then assert the result.
+
+Key points:
+
+- **Always inject `MutableInteractionSource`** rather than relying on the default internal source. This gives you full control over state transitions.
+- **Emit interactions from a coroutine scope** (e.g. `TestScope().launch { }`) since `emit` is a suspend function. Do not use `LaunchedEffect` — that is a production Compose effect, not a test tool.
+- **Assert the *result* of the interaction** (visual change, semantic change, enabled state), not the interaction itself. The interaction source is a test *driver*, not the assertion target.
+- **Use this for screenshot tests too** — emit the interaction state, then capture the screenshot for a deterministic hover/press/focus visual.
+
+## Keyboard and focus
+
+For keyboard, TV, and desktop UI, drive navigation with the same input model users use (keys/D-pad), not clicks alone. Assert focused semantics, not colors or scale; reserve screenshots for visual focus treatment.
+
+Details—focus graph, `FocusRequester`, restoration, key handlers, and test patterns: [`compose-focus-navigation`](../compose-focus-navigation/SKILL.md).
+
+## Screenshot tests
+
+Use screenshots for visual contracts that semantics cannot prove:
+
+- Layout spacing/alignment.
+- Themed colors, typography, elevation, shadows.
+- Image composition, gradients, overlays.
+- Focus highlight appearance.
+- Loading skeletons or dense visual states.
+
+Keep screenshot state deterministic:
+
+- Use fixed state data.
+- Freeze clocks or animation progress when possible.
+- Replace network/image loading with fake or preview handlers.
+- Avoid asserting dynamic text such as current time unless controlled.
+
+## Fake images and platform services
+
+When image content is irrelevant, fake the loader and assert the requested model if that is the behavior. The exact hook depends on your image library; a project helper might look like this:
+
+```kotlin
+val requestedModels = mutableListOf<Any?>()
+
+// Example helper, not a Compose API.
+setContentWithFakeImageLoader { request ->
+    requestedModels += request.data
+    errorPainter()
+}
+```
+
+When image appearance matters, provide a deterministic local painter/bitmap instead of network data.
+
+## Common mistakes
+
+| Mistake | Fix |
+|---|---|
+| Constructing full app graph to test an error row | Test plain UI with `state = Error` |
+| Testing click behavior through a ViewModel mock | Pass a callback and assert it was invoked |
+| Screenshot test for simple text presence | Use semantics assertion |
+| Semantics test for padding/color/focus ring | Use screenshot test |
+| Test tags everywhere | Prefer text/content description/role when stable |
+| UI test depends on real image loading/network/time | Fake or freeze the source |
+| Simulating hover/press/focus with mouse or touch events | Inject `MutableInteractionSource` and emit the interaction |
+| Relying on the default `InteractionSource` in tests | Pass `MutableInteractionSource` so you can control state |
+| TV/keyboard UI tested with `performClick` only | Use key input and focus assertions; see [compose-focus-navigation](../compose-focus-navigation/SKILL.md) |
+
+## Red flags during review
+
+- "This UI test is flaky because images load slowly."
+- A test uses production DI for simple rendering.
+- A screenshot has random dates, clocks, remote images, or live data.
+- Assertions only check that a node exists after performing an action, not that the callback/state change happened.
+- Focus behavior is visually inspected but not asserted.
+- A test uses `performMouseInput` or touch injection to trigger hover/press states instead of `MutableInteractionSource.emit`.
+- A composable accepts `interactionSource` but tests don't inject `MutableInteractionSource`.

--- a/.agents/skills/kotlin-coroutines-structured-concurrency/SKILL.md
+++ b/.agents/skills/kotlin-coroutines-structured-concurrency/SKILL.md
@@ -1,0 +1,444 @@
+---
+description: Use when writing or reviewing Kotlin code that stores CoroutineScope, launches from init/non-suspending APIs, calls runBlocking, or catches broad exceptions around suspend calls.
+metadata:
+    github-path: skills/kotlin-coroutines-structured-concurrency
+    github-ref: refs/tags/2026.05.21
+    github-repo: https://github.com/chrisbanes/skills
+    github-tree-sha: 3045cddcb91e9c0bc2fe71676a7966444d558b55
+name: kotlin-coroutines-structured-concurrency
+---
+# Kotlin coroutines: structured concurrency
+
+## Core principle
+
+A well-structured coroutine is a self-contained unit of asynchronous work — single entry, single exit, scoped to a lifecycle known at the call site.
+
+**Scopes should usually be tied to the caller's lifecycle, not stored as a property on the callee.** A stored `CoroutineScope` is a strong review signal: the class must prove it owns cancellation, error reporting, restart behavior, and lifecycle. Most repositories, managers, use cases, and data sources cannot prove that, so they should expose `suspend` APIs instead.
+
+The fix is almost always the same: **make the API `suspend` and let the caller own the scope.**
+
+## When to use this skill
+
+You're writing or reviewing Kotlin code and you see any of these:
+
+- A class with `private val scope: CoroutineScope` (constructor param stored as a property)
+- An `init { scope.launch { ... } }` block
+- A non-suspending public function whose body is `scope.launch { ... }`
+- `runBlocking { ... }` in suspend-capable application code, or in tests where `runTest` should apply
+- `runCatching { suspendCall() }` or a `catch` on `Exception` / `Throwable` around a `suspend` call without rethrowing `CancellationException`
+- A `catch (e: CancellationException)` (or equivalent) around suspension that does not rethrow
+
+## The silent-cancellation bug
+
+The reason an unowned `CoroutineScope` property is so dangerous: **once a scope is cancelled, every future `launch` on it silently completes as cancelled — no exception, no log, nothing.** The work just doesn't happen. This is one of the hardest coroutine bugs to diagnose, and it appears when a class holds a long-lived reference to a lifecycle it does not own.
+
+If APIs are `suspend`, this can't happen: the caller's scope is either alive (work runs) or the call site cancels (the caller knows).
+
+## Anti-patterns and fixes
+
+### 1. CoroutineScope stored as a property
+
+```kotlin
+// ❌ BAD
+@Inject
+class UserRepository(
+    private val scope: CoroutineScope,
+    private val api: UserApi,
+) {
+    fun refresh() {
+        scope.launch { _state.value = api.fetchUser() }
+    }
+}
+
+// ✅ GOOD
+@Inject
+class UserRepository(
+    private val api: UserApi,
+) {
+    suspend fun refresh(): User = api.fetchUser()
+}
+```
+
+The repository no longer needs to know about coroutines at all. The caller (a ViewModel, a use case) decides on what scope, with what error handling, with what cancellation semantics.
+
+### 2. init-block launches
+
+```kotlin
+// ❌ BAD: construction-time side effect, unbounded work
+class UserSession(private val scope: CoroutineScope, private val api: Api) {
+    init { scope.launch { _user.value = api.load() } }
+}
+```
+
+The constructor returns immediately. The caller can't `await` the load, can't see errors, can't cancel. The class is "alive" but its state is undefined.
+
+```kotlin
+// ✅ GOOD: explicit bootstrap, caller owns the suspension
+class UserSession(private val api: Api) {
+    private var _user: User? = null
+    val user: User get() = checkNotNull(_user) { "Call init() first" }
+
+    suspend fun init() { _user = api.load() }
+}
+```
+
+### 3. Fire-and-forget from non-UI classes
+
+A non-suspending public function on a **non-UI class** (repository, manager, use case, data source) that launches into a class-owned scope. The caller gets no result, no error, no cancellation, and no guarantee the work ever ran.
+
+```kotlin
+// ❌ BAD — repository with stored scope and fire-and-forget public API
+class AnalyticsClient(private val scope: CoroutineScope, private val api: Api) {
+    fun track(event: Event) {
+        scope.launch { api.send(event) }      // caller has no idea what happens
+    }
+    fun signOut() {
+        scope.launch { api.signOut() }        // silent failure if scope cancelled
+    }
+}
+```
+
+```kotlin
+// ✅ GOOD
+class AnalyticsClient(private val api: Api) {
+    suspend fun track(event: Event) = api.send(event)
+    suspend fun signOut() = api.signOut()
+}
+```
+
+#### Carve-out: the UI ↔ state-holder boundary
+
+UI frameworks are non-suspending. A Composable's `onClick`, a Fragment's `onKeyEvent`, an Activity's `onNewIntent` — none can `suspend`. The state holder (ViewModel, Decompose Component, feature model, etc. — anything whose role is to absorb UI events and hold UI state) **is** the boundary that translates one-shot UI events into asynchronous work bound to the UI lifecycle. That's its job.
+
+```kotlin
+// ✅ GOOD — state holder absorbs a non-suspending UI event onto its scope
+class FavouritesViewModel(private val repo: FavouritesRepository) : ViewModel() {
+    fun onToggleFavourite(item: Item) {
+        viewModelScope.launch { repo.toggleFavourite(item) }
+    }
+}
+
+// in Compose:
+ListItem(onClick = { viewModel.onToggleFavourite(item) })
+```
+
+This is **not** the fire-and-forget anti-pattern. All three conditions must hold:
+
+1. **State holder for a UI surface** — a ViewModel, Decompose Component, feature model, or equivalent UI state holder. Not a repository, manager, use case, or data source.
+2. **Lifecycle-bound scope** — `viewModelScope`, a Component's `coroutineScope` that's cancelled on destroy, a Composable's `rememberCoroutineScope()`. Not `AppScope`, not an injected long-lived scope, not an ad-hoc `CoroutineScope(...)`.
+3. **Caller really is a UI event** — Composable callback, key handler, lifecycle hook. Not another business-logic class calling through the state holder.
+
+The repository / use case / data source layers underneath still expose `suspend` APIs. The state holder is the *only* layer where the non-suspending → suspending translation belongs.
+
+"It feels like a state holder" isn't enough. The question is "does the UI directly bind to this?" If no, the carve-out doesn't apply.
+
+### 4. Stored scopes that aren't injected
+
+The same anti-pattern, without an injected scope:
+
+```kotlin
+// ❌ BAD — same problem, scope is constructed in-class instead of injected
+class FooManager {
+    private val scope = MainScope()
+    private val scope = CoroutineScope(Dispatchers.Default + SupervisorJob())
+}
+```
+
+Lifecycle is now owned by nothing and lives forever. Replace with `suspend` APIs.
+
+The same is true if the instantiation is nested inside a function body — `fun foo() { CoroutineScope(...).launch { … } }` is just a stored scope with extra steps. Each call leaks a new uncancellable scope; bundling it into a `by lazy` property doesn't fix the underlying issue (the scope shouldn't exist at all).
+
+### 5. DI-bound singletons / initializers that launch
+
+A specific pattern that is hard to spot: a DI-bound class (`@SingleIn(AppScope)`, `@Singleton`, an `Initializer.initialize()`) launches a coroutine from its constructor / `init` block / `initialize()`. The launched work then has:
+
+- **A non-deterministic start time** — whenever the graph realizes the binding. Cold-start ordering is invisible.
+- **No observable lifecycle.** Nothing else in the codebase can see whether it's running or has crashed.
+- **No `stop()` / restart path.** If upstream enters a bad state, the loop is uncancellable.
+- **No calling code to grep for.** Readers can't find "who starts this and when".
+
+§1 says scopes should be tied to the caller's lifecycle. The DI-bound variant violates this indirectly: the *scope* may be injected, but the *launch* is hidden inside construction — same effect, harder to see.
+
+```kotlin
+// ❌ BAD — singleton boots work as a side effect of being constructed
+@SingleIn(AppScope::class)
+@Inject
+class TokenRefresher(
+    @ForScope(AppScope::class) private val scope: CoroutineScope,
+    private val auth: AuthService,
+) {
+    init {
+        scope.launch {
+            while (isActive) {
+                delay(5.minutes)
+                auth.refreshIfNeeded()
+            }
+        }
+    }
+}
+
+// ❌ ALSO BAD — Initializer.initialize() that *launches*, not just registers
+class TokenInvalidatorInitializer @Inject constructor(
+    @ForScope(AppScope::class) private val scope: CoroutineScope,
+    private val store: AuthStore,
+    private val invalidator: TokenInvalidator,
+) : Initializer {
+    override fun initialize() {
+        scope.launch { store.tokenChanges.collect { invalidator.invalidate() } }
+    }
+}
+```
+
+Both look like "application-scoped singletons", but the **When NOT to apply** carve-out is *not* permission to launch from `init` / `initialize()`. It's permission for a singleton to own a scope when its API is suspending.
+
+#### First ask: does this background-loop class need to exist at all?
+
+Most background-loop classes exist only because no one inverted the observation. Three answers, in order of preference:
+
+**Pattern 1 — invert into the consumer.** The class observes state forever to react when it changes. But *someone* mutates the state — sign-out flow, profile switch, flag-update handler. That mutation site is already in a coroutine context and is the natural place to do the work directly.
+
+```kotlin
+// ✅ GOOD — no background loop, no scope, no class. The mutation site does the work.
+class Authenticator(
+    private val authStore: AuthStore,
+    private val tokenInvalidator: TokenInvalidator,
+) {
+    suspend fun signOut() {
+        authStore.clearTokens()
+        tokenInvalidator.invalidate()   // direct call at the mutation site
+    }
+}
+```
+
+The background-loop class is **deleted**. The work happens where the state changes.
+
+When this applies: the consumer of the state has a clear lifecycle (a use case, an Authenticator, a service handler) and can perform the reaction inline.
+
+**Pattern 2 — scheduled work.** Genuinely periodic or deferred. Use WorkManager / BGTaskScheduler. The enqueue is one-shot; make it suspending and call it once from an orchestrator that already runs at startup.
+
+**Pattern 3 — explicit named launch site.** Sometimes the consumer is a synchronous API with no observable lifecycle (e.g., OpenTelemetry's `Sampler.shouldSample(...)`, an AIDL stub fanout, a broadcast receiver bridge). The observation has to live somewhere coroutine-aware, but it must live at an *explicit named call site* — not in the class's own `init`.
+
+```kotlin
+// ✅ GOOD — work is named; an explicit call site owns the launch
+@SingleIn(AppScope::class)
+class OtelConfigurableSampler(...) : Sampler {
+    @Volatile private var delegate: Sampler = ...
+
+    suspend fun observeRate(featureFlags: FeatureFlags) {
+        featureFlags.observe(OTEL_SAMPLING_RATE).collect { rate ->
+            delegate = Sampler.traceIdRatioBased(rate.coerceIn(0.0, 1.0))
+        }
+    }
+
+    override fun shouldSample(...) = delegate.shouldSample(...)
+}
+
+// wired explicitly at the OTel SDK init module:
+applicationScope.launch { otelSampler.observeRate(featureFlags) }
+```
+
+When this applies: the consumer is a synchronous API that calls *into* you with no observable lifecycle. The launch can't be invertible, but it must still be visible at a named call site.
+
+#### Test for which pattern fits
+
+"Is the consumer's lifecycle observable to me?"
+
+- **Yes, and they're already in a coroutine context** → Pattern 1. Push the subscription into them; delete the background-loop class.
+- **The work is periodic / deferred** → Pattern 2. Suspend enqueue called once.
+- **No, they're a synchronous API with no observable lifecycle** → Pattern 3. Explicit launch site, not `init`.
+
+If a fourth answer seems to fit — e.g., "I want a `Bootable` interface that launches everything for me" — that's the same anti-pattern with an extra layer of abstraction. The whole point is that launches be *visible*; auto-discovery by interface defeats it.
+
+#### Initializers are still fine — *if they only register*
+
+The `Initializer` pattern is correct when `initialize()` *registers* a listener or hook. The bug is when `initialize()` *launches* a coroutine.
+
+```kotlin
+// ✅ GOOD Initializer — registers a contributor, doesn't launch
+class FavouritesContributorInitializer @Inject constructor(
+    private val registry: ContributorRegistry,
+    private val favouritesContributor: FavouritesContributor,
+) : Initializer {
+    override fun initialize() {
+        registry.register(favouritesContributor)
+    }
+}
+```
+
+**`Initializer.initialize()` must not `launch` a coroutine.** If yours does, it's a Pattern 1/2/3 candidate.
+
+#### Diagnostic for review
+
+- Where is the start moment defined? If "wherever DI realizes me", bad.
+- Who can observe whether the work is running? If "no one", bad.
+- Who can stop or restart it? If "no one", bad.
+- Can a reader grep for the launch site? If no, bad.
+
+If the answers are "the consumer / the orchestrator / the named call site" — you're good.
+
+### 6. Swallowing `CancellationException`
+
+A `catch` clause around a `suspend` call that matches `CancellationException` — directly, or through `Exception` / `Throwable` — and doesn't rethrow usually turns cancellation into silent success. The parent coroutine thinks the child finished; the child keeps running (or its side effects do); the cancellation contract is broken.
+
+Same failure shape as §1's stored-scope bug, viewed from the other end: §1 hides the work *from* the caller's lifecycle; this hides cancellation *from* the work.
+
+```kotlin
+// ❌ BAD — catches CancellationException, never rethrows
+suspend fun fetch() {
+    try {
+        api.load()
+    } catch (e: Exception) {           // matches CancellationException too
+        logger.warn("load failed", e)
+    }
+}
+
+// ❌ ALSO BAD — runCatching has the same problem
+suspend fun fetch() {
+    runCatching { api.load() }
+        .onFailure { logger.warn("load failed", it) }
+}
+```
+
+The acceptable shapes:
+
+```kotlin
+// ✅ Separate catch first
+try { api.load() }
+catch (e: CancellationException) { throw e }
+catch (e: Exception) { logger.warn("load failed", e) }
+
+// ✅ Conditional rethrow inside the broad catch
+try { api.load() }
+catch (e: Exception) {
+    if (e is CancellationException) throw e
+    logger.warn("load failed", e)
+}
+
+// ✅ ensureActive() — good when the catch handles ordinary failures and you only need
+// to rethrow if the current coroutine is cancelled
+try { api.load() }
+catch (e: Exception) {
+    currentCoroutineContext().ensureActive()
+    logger.warn("load failed", e)
+}
+
+// ✅ runCatching with explicit guard
+runCatching { api.load() }
+    .onFailure {
+        if (it is CancellationException) throw it
+        logger.warn("load failed", it)
+    }
+
+// ✅ runCatching terminated with getOrThrow (cancellation flows back out)
+runCatching { api.load() }.getOrThrow()
+```
+
+The trigger is "a suspend call inside the `try`", not "the enclosing function is declared `suspend`". This applies inside any suspending body — `suspend fun`, a `launch { … }` lambda, a Flow `collect { … }`, etc.
+
+The common carve-out is an intentionally local timeout: catching `TimeoutCancellationException` from your own `withTimeout` and converting it to a domain result can be correct. Keep that catch narrow and close to the timeout. Do not use it as permission to swallow arbitrary cancellation.
+
+Catching a non-cancellation subtype (`IOException`, your own exception types) is fine — they don't extend `CancellationException`.
+
+### 7. `runBlocking`
+
+`runBlocking` parks the current thread until the lambda finishes. Inside suspend-capable or lifecycle-scoped application paths it is wrong: a thread that meant to be async is now blocked, structured concurrency is broken, and any cancellation upstream has no effect. It is the "callee makes a structural decision for the caller" anti-pattern at its most direct.
+
+```kotlin
+// ❌ BAD — bridging to suspend by blocking the calling thread
+fun saveUser(user: User) {
+    runBlocking { repository.save(user) }
+}
+```
+
+Three fixes, by context:
+
+**Suspend-capable application code** — make the function `suspend`:
+
+```kotlin
+// ✅ GOOD
+suspend fun saveUser(user: User) = repository.save(user)
+```
+
+If the immediate caller can't suspend either (a non-suspending UI callback, a `BroadcastReceiver` hook), use the existing lifecycle-bound scope at the boundary — see §3's UI ↔ state-holder carve-out. The fix is at the boundary, not inside `saveUser`.
+
+Legitimate blocking boundaries exist: `main` in a CLI tool, Java interop APIs that must return synchronously, framework callbacks with no suspending alternative, and migration shims. Keep `runBlocking` at that outer boundary, keep the body small, and call suspending code immediately.
+
+**Tests** — use `runTest`:
+
+```kotlin
+// ❌ BAD — real time, slow tests, no virtual delay
+@Test fun loadsUser() = runBlocking {
+    assertThat(repository.load().name).isEqualTo("Alice")
+}
+
+// ✅ GOOD
+@Test fun loadsUser() = runTest {
+    assertThat(repository.load().name).isEqualTo("Alice")
+}
+```
+
+`runTest` gives you virtual time (`delay()` returns immediately), `TestDispatcher` integration, and proper coroutine cleanup. Real-time `runBlocking` in tests makes them slow and flaky.
+
+**`ContentProvider` carve-out** — Android's `ContentProvider` methods (`query`, `insert`, `update`, `delete`, `onCreate`, `call`) are synchronous from outside the process. There is no way to suspend them. Inside *member functions* of a `ContentProvider` subclass (direct or indirect — not companion objects), `runBlocking` is the unavoidable bridge. Keep the body as short as possible and call into suspending code immediately:
+
+```kotlin
+// ✅ Acceptable in ContentProvider members only
+class MyProvider : ContentProvider() {
+    override fun query(...): Cursor? = runBlocking { dao.query(...) }
+}
+```
+
+This carve-out is for `android.content.ContentProvider` subclasses *only*. "It's like a `ContentProvider`" doesn't apply, and a `runBlocking` in a `ContentProvider`'s companion object is still a regular violation — the helper isn't part of the framework's synchronous surface.
+
+## Quick reference
+
+| Symptom | Anti-pattern | Fix |
+|---|---|---|
+| Class has `private val scope: CoroutineScope` | Stored scope on the callee | Remove. Make public APIs `suspend`. |
+| `init { scope.launch { ... } }` | Construction-time launch | Move to `suspend fun init()` / `login()` |
+| `fun foo() { scope.launch { ... } }` on a repository/manager/use case | Fire-and-forget from non-UI class | `suspend fun foo()`, let UI state holder pick the scope |
+| `fun onClick() { viewModelScope.launch { ... } }` on a state holder, called from UI | UI ↔ state-holder boundary — fine | Keep as-is (see §3 carve-out) |
+| `private val scope = MainScope()` | Internally-constructed stored scope | Same — remove, make APIs `suspend` |
+| `@SingleIn(AppScope) class X(scope) { init { scope.launch { … } } }` | DI-bound opaque launch (§5) | Expose `suspend fun run()`, launch from startup orchestrator |
+| `class Y : Initializer { override fun initialize() { scope.launch { … } } }` | Initializer that launches, not registers (§5) | Same — `suspend fun run()`, orchestrator owns lifecycle |
+| `try { suspendCall() } catch (e: Exception\|Throwable\|CancellationException) { … }` with no rethrow | Swallowed cancellation (§6) | Prefer `catch (e: CancellationException) { throw e }`; use `ensureActive()` only when that matches the intent |
+| `runCatching { suspendCall() }.onFailure { … }` with no cancellation guard | Same shape as above (§6) | Add `if (it is CancellationException) throw it`, or terminate with `.getOrThrow()` |
+| `runBlocking { … }` inside suspend-capable app code | Thread-blocking bridge (§7) | Make caller `suspend`; or use a lifecycle scope at the boundary |
+| `runBlocking { … }` in a test | Same — real-time bridging (§7) | Use `runTest { … }` |
+| `runBlocking { … }` inside a `ContentProvider.query`/`insert`/… member | Carve-out (§7) | Acceptable; keep the body minimal |
+
+## Refactoring guidance
+
+Removing an existing offender:
+
+1. **Start at the leaf.** Pick the class farthest from any UI — usually a repository or data source. Its public surface should be the easiest to convert.
+2. **Convert public functions to `suspend`** one at a time. The compiler will surface every caller.
+3. **At each caller, choose the scope deliberately:** `viewModelScope`, `lifecycleScope`, `coroutineScope { }`, or an explicit job. This is the choice that was missing before.
+4. **Delete the `CoroutineScope` constructor parameter** once nothing uses it. Remove the injection binding.
+
+Don't try to fix every class in one MR. Removing an anti-pattern is incremental work.
+
+## When NOT to apply
+
+- **UI state holders absorbing UI events.** A ViewModel/Component/feature model with `fun onClick(...) { viewModelScope.launch { ... } }` is correct — that's the boundary the framework needs. See §3 carve-out.
+- **Lifecycle owners with explicit cancellation and error policy.** Actors/services, app infrastructure, or application-scoped singletons may own a scope when they expose clear `close`/`cancel`/restart behavior or otherwise map directly to an application lifecycle. Inject `Application.applicationScope` explicitly rather than creating one ad-hoc. **This is not permission to launch from `init` / `initialize()`** — see §5.
+- **Already-suspending APIs** don't need any of this work.
+- **Tests** sometimes use `TestScope` as a deliberate ambient scope — that's a different pattern with explicit virtual-time control.
+
+## Red flags during review
+
+These thoughts mean the anti-pattern is back:
+
+| Thought | Reality |
+|---|---|
+| "I'll just add a `CoroutineExceptionHandler` to the scope" | The problem isn't error handling. The problem is the scope shouldn't exist. |
+| "I need to launch from `init` so the data's ready when consumers arrive" | Consumers reading state that isn't ready is the bug. Use phasing. |
+| "The caller doesn't want to deal with `suspend`" | Then the caller chooses fire-and-forget at their scope. Don't decide for them. |
+| "It's just a small fire-and-forget call" | Silent cancellation makes every fire-and-forget a potential silent failure. |
+| "We caught and logged the exception, so we're fine" | Did the catch rethrow `CancellationException`? If no, the coroutine is silently un-cancelled. (§6) |
+| "It's just one `runBlocking`, in a non-critical path" | Every `runBlocking` asserts the caller has no async option. If they do, it's the wrong primitive. (§7) |
+| "Tests are simpler with `runBlocking`" | They run in real time, can't fast-forward `delay`, and lose `TestDispatcher` semantics. Use `runTest`. (§7) |
+
+## Related
+
+- [`kotlin-flow-state-event-modeling`](../kotlin-flow-state-event-modeling/SKILL.md) — `StateFlow`, `SharedFlow`, `Channel`, `stateIn`, one-shot events, and related modeling.

--- a/.agents/skills/kotlin-flow-state-event-modeling/SKILL.md
+++ b/.agents/skills/kotlin-flow-state-event-modeling/SKILL.md
@@ -1,0 +1,187 @@
+---
+description: Use when writing or reviewing Kotlin Flow state and event APIs with StateFlow, MutableStateFlow.update, SharedFlow, Channel, stateIn, SharingStarted, .value, receiveAsFlow, one-shot events, or sentinel initial values.
+metadata:
+    github-path: skills/kotlin-flow-state-event-modeling
+    github-ref: refs/tags/2026.05.21
+    github-repo: https://github.com/chrisbanes/skills
+    github-tree-sha: f849f7dc820c3be59f5bead0ad1ee241b27d1f28
+name: kotlin-flow-state-event-modeling
+---
+# Kotlin Flow: state and event modeling
+
+## Core principle
+
+**Pick the primitive that matches replay, fan-out, and synchronous-read requirements.** `StateFlow`, `SharedFlow`, `Channel`-backed flows, and cold `Flow` differ in buffering, who sees each emission, and whether `.value` exists. Wrong choices drop events, leak sharing coroutines, or force fake domain sentinels into state.
+
+## When to use this skill
+
+You're writing or reviewing Kotlin code involving:
+
+- `MutableStateFlow<T>(SomeSentinel)` — `NoUser`, `Empty`, `Loading`, etc. — because the real value is async
+- `.stateIn(...)` called inside a function rather than assigned to a property
+- `SharingStarted.WhileSubscribed(...)` on a flow whose `.value` is read synchronously and must stay fresh
+- `MutableSharedFlow` for navigation events, snackbars, or other one-shot emissions where loss would be a bug
+- `.map { }` on a `StateFlow` when consumers still need synchronous `.value`
+- `MutableStateFlow.value = _state.value.copy(...)` or update code that builds expensive objects inside `update { ... }`
+
+## SharedFlow for single-consumer fire-once events
+
+`SharedFlow` defaults have no replay buffer. If nothing is collecting at the exact instant of emission, the event is gone. For a **single UI consumer** handling exactly-once events such as navigation or snackbars, a buffered `Channel` exposed as a `Flow` often matches the semantics better:
+
+```kotlin
+// ❌ BAD
+private val _navEvents = MutableSharedFlow<NavigationEvent>()
+val navEvents: SharedFlow<NavigationEvent> = _navEvents.asSharedFlow()
+
+// ✅ GOOD
+private val _navEvents = Channel<NavigationEvent>(Channel.BUFFERED)
+val navEvents: Flow<NavigationEvent> = _navEvents.receiveAsFlow()
+```
+
+`Channel.receiveAsFlow()` is **fan-out, not broadcast**: with multiple collectors, each event is delivered to **one** collector. `Channel.BUFFERED` is bounded, so sends can suspend and `trySend` can fail. If multiple observers must all see the same event, use explicit state, durable storage, or a deliberately configured `SharedFlow` instead.
+
+## StateFlow polluted with invalid sentinel defaults
+
+`StateFlow` forces an initial value. When the real value is async, developers sometimes invent fake domain values — `NoUser`, `EmptyUser`, placeholder IDs — and every consumer is forced to treat that sentinel as real data.
+
+```kotlin
+// ❌ BAD — sentinel leaks into the type
+class UserSession(private val db: Db) {
+    private val _user = MutableStateFlow<User>(NoUser)
+    val user: StateFlow<User> = _user.asStateFlow()
+    init { scope.launch { _user.value = db.load() } }
+}
+```
+
+One fix is **phasing**: don't expose the `StateFlow` until the real value exists.
+
+```kotlin
+// ✅ GOOD — bootstrap suspends; observers only see real users
+class UserSession(private val db: Db) {
+    private var _user: MutableStateFlow<User>? = null
+    val user: StateFlow<User>
+        get() = checkNotNull(_user) { "Call login() first" }
+
+    suspend fun login() {
+        _user = MutableStateFlow(db.load())
+    }
+}
+```
+
+If absence, loading, or error is a real state, model it explicitly (`User?`, `sealed interface UserUiState`, `Result`, etc.). The bug is a fake domain value masquerading as real data, not every initial value.
+
+## Mutate MutableStateFlow with `update { ... }`
+
+Prefer `MutableStateFlow.update { current -> ... }` over reading `.value` and writing it back. `update` applies the transform atomically against the latest state, which avoids lost updates when multiple coroutines mutate the same state.
+
+```kotlin
+// BAD — read/modify/write can lose concurrent updates.
+_state.value = _state.value.copy(
+    selectedId = id,
+    details = details,
+)
+
+// GOOD — transform starts from the latest state.
+_state.update { current ->
+    current.copy(
+        selectedId = id,
+        details = details,
+    )
+}
+```
+
+Keep object creation outside the `update` block unless it needs the current state. The update lambda can be retried, so expensive work or side effects inside it may run more than once:
+
+```kotlin
+// GOOD — details does not depend on current state, so build it once.
+val details = Details.from(response)
+_state.update { current ->
+    current.copy(details = details)
+}
+
+// GOOD — derived value depends on current state, so compute it inside.
+_state.update { current ->
+    val nextItems = current.items.replaceById(updatedItem)
+    current.copy(items = nextItems)
+}
+```
+
+The block should be a pure, fast state transformation: no network calls, database writes, logging side effects, random IDs, or time reads unless those values were captured before the block.
+
+## `stateIn()` inside a function
+
+```kotlin
+// ❌ BAD — new sharing coroutine every call
+fun getPreferences(): StateFlow<Prefs> =
+    repo.prefsFlow.stateIn(scope, SharingStarted.Eagerly, Prefs.Default)
+```
+
+Every call to `getPreferences()` launches a fresh coroutine on `scope` that never completes. Performance dies fast under repeated reads.
+
+```kotlin
+// ✅ GOOD — one shared instance, computed once
+val preferences: StateFlow<Prefs> =
+    repo.prefsFlow.stateIn(viewModelScope, SharingStarted.Eagerly, Prefs.Default)
+```
+
+## `WhileSubscribed` with synchronous `.value`
+
+`SharingStarted.WhileSubscribed(timeout)` disconnects the upstream when there are no active collectors. While disconnected, `.value` returns the last cached value, which may be stale or still the initial value.
+
+**Rule:** if `.value` must be fresh or initialized without an active collector, use `SharingStarted.Eagerly` or explicit initialization. `WhileSubscribed` is fine when stale/cached values are acceptable and consumers primarily collect asynchronously.
+
+## `.map` on `StateFlow` loses `.value`
+
+```kotlin
+// ❌ BAD — `name.value` won't compile; it's now a plain Flow
+val name: Flow<String> = userState.map { it.name }
+```
+
+If you need synchronous `.value`, terminate the chain with `.stateIn(...)`:
+
+```kotlin
+// ✅ GOOD
+val name: StateFlow<String> = userState
+    .map { it.name }
+    .stateIn(viewModelScope, SharingStarted.Eagerly, userState.value.name)
+```
+
+Community “derived state flow” utilities run the transform on every `.value` read — only acceptable for fast, idempotent transforms. Default to `.stateIn(...)`.
+
+## Decision: which Flow type?
+
+| Need | Primitive |
+|------|-----------|
+| State that always has a value, read by both async collectors **and** synchronous code | `StateFlow`, often with `SharingStarted.Eagerly` when `.value` matters |
+| Hot stream, multiple subscribers, **no** requirement for synchronous `.value` | `SharedFlow` |
+| Discrete events for **one** consumer, exactly-once handoff | Consider `Channel(BUFFERED).receiveAsFlow()` |
+| Cold stream, one consumer per collection | Plain `Flow` |
+
+If you're tempted to reach for `SharedFlow`, ask: would dropping an emission be a bug, and how many consumers must see it? If one consumer must handle it exactly once, a `Channel` may fit. If every observer must see it, model durable state or configure a broadcast stream deliberately.
+
+## Quick reference
+
+| Symptom | Problem | Fix |
+|---------|---------|-----|
+| `MutableStateFlow<X>(FakeDomainValue)` | Invalid placeholder default | Model absence explicitly or use phase initialization |
+| `MutableSharedFlow<Event>` for single-consumer nav/snackbar | Lossy default event stream | Consider `Channel(BUFFERED).receiveAsFlow()` |
+| `fun foo() = flow.stateIn(...)` | Per-call sharing coroutine | Make it a `val` / shared instance |
+| `WhileSubscribed` + `.value` must be fresh/initialized | Stale or initial data | `SharingStarted.Eagerly` or explicit initialization |
+| `stateFlow.map { ... }` consumed as state | Lost `.value` | Terminate with `.stateIn(...)` |
+| `_state.value = _state.value.copy(...)` | Non-atomic read/modify/write | `_state.update { it.copy(...) }` |
+| Expensive object creation inside `update { ... }` that doesn't use current state | Work can repeat if update retries | Build before `update`; keep only current-state transforms inside |
+
+## Red flags during review
+
+| Thought | Reality |
+|---------|---------|
+| "We need `SharedFlow` because there are multiple subscribers" | Multiple subscribers change the semantics. `Channel.receiveAsFlow()` is not broadcast; choose the event model deliberately. |
+| "We'll use `WhileSubscribed` to save resources" | Only if stale/initial `.value` reads are acceptable. Verify before applying. |
+| "I'll use a sentinel until real data loads" | Consumers treat it as real domain; prefer explicit UI/state modeling or phasing. |
+| "I'll construct the new object inside `update` because it's convenient" | The lambda may retry. Construct outside unless it depends on the current state. |
+
+## Related
+
+- [`kotlin-coroutines-structured-concurrency`](../kotlin-coroutines-structured-concurrency/SKILL.md) — scope ownership, init launches, fire-and-forget boundaries, cancellation, `runBlocking`
+- [`compose-side-effects`](../compose-side-effects/SKILL.md) — collecting event flows and wiring side effects in Compose
+- [`compose-state-holder-ui-split`](../compose-state-holder-ui-split/SKILL.md) — where state holders expose flows to UI

--- a/library/src/androidTest/AndroidManifest.xml
+++ b/library/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
+
+</manifest>

--- a/library/src/androidTest/java/com/github/only52607/compose/window/FloatingWindowInstrumentedTest.kt
+++ b/library/src/androidTest/java/com/github/only52607/compose/window/FloatingWindowInstrumentedTest.kt
@@ -1,0 +1,118 @@
+package com.github.only52607.compose.window
+
+import android.os.ParcelFileDescriptor
+import androidx.compose.material3.Text
+import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.Lifecycle
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.github.only52607.compose.service.ComposeServiceFloatingWindow
+import org.junit.After
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.FileInputStream
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+@RunWith(AndroidJUnit4::class)
+class FloatingWindowInstrumentedTest {
+
+    private val instrumentation = InstrumentationRegistry.getInstrumentation()
+    private val context = instrumentation.targetContext
+    private val windows = mutableListOf<ComposeServiceFloatingWindow>()
+
+    @Before
+    fun allowOverlayWindows() {
+        executeShellCommand("cmd appops set ${context.packageName} SYSTEM_ALERT_WINDOW allow")
+    }
+
+    @After
+    fun closeWindows() {
+        instrumentation.runOnMainSync {
+            windows.forEach { window ->
+                window.close()
+            }
+            windows.clear()
+        }
+    }
+
+    @Test
+    fun showMovesLifecycleToStartedImmediately() {
+        val window = newWindow()
+
+        instrumentation.runOnMainSync {
+            window.setContent {
+                Text("Ready")
+            }
+            window.show()
+        }
+
+        assertTrue(
+            "Floating window lifecycle should be STARTED immediately after show().",
+            window.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED),
+        )
+    }
+
+    @Test
+    fun composeContentRecomposesAfterStateChangeWithoutMovingWindow() {
+        val window = newWindow()
+        var label by mutableStateOf("Before")
+        val initialComposition = CountDownLatch(1)
+        val updatedComposition = CountDownLatch(1)
+
+        instrumentation.runOnMainSync {
+            window.setContent {
+                Text(text = label)
+                SideEffect {
+                    when (label) {
+                        "Before" -> initialComposition.countDown()
+                        "After" -> updatedComposition.countDown()
+                    }
+                }
+            }
+            window.show()
+        }
+
+        assertTrue(
+            "Initial floating window composition did not run.",
+            initialComposition.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+        )
+
+        instrumentation.runOnMainSync {
+            label = "After"
+        }
+
+        assertTrue(
+            "Floating window did not recompose after state changed.",
+            updatedComposition.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+        )
+    }
+
+    private fun newWindow(): ComposeServiceFloatingWindow {
+        lateinit var window: ComposeServiceFloatingWindow
+        instrumentation.runOnMainSync {
+            window = ComposeServiceFloatingWindow(context)
+            windows += window
+            assertTrue(
+                "SYSTEM_ALERT_WINDOW app-op was not granted for the test package.",
+                window.isAvailable(),
+            )
+        }
+        return window
+    }
+
+    private fun executeShellCommand(command: String) {
+        val descriptor: ParcelFileDescriptor = instrumentation.uiAutomation.executeShellCommand(command)
+        FileInputStream(descriptor.fileDescriptor).bufferedReader().use { it.readText() }
+        descriptor.close()
+    }
+
+    private companion object {
+        const val TIMEOUT_SECONDS = 3L
+    }
+}

--- a/library/src/main/kotlin/com/github/only52607/compose/core/CoreFloatingWindow.kt
+++ b/library/src/main/kotlin/com/github/only52607/compose/core/CoreFloatingWindow.kt
@@ -2,6 +2,8 @@ package com.github.only52607.compose.core
 
 import android.app.Application
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import android.provider.Settings
 import android.util.Log
 import android.view.ViewGroup
@@ -26,9 +28,6 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.sync.Mutex
-import kotlinx.coroutines.sync.withLock
 import kotlin.coroutines.cancellation.CancellationException
 
 public abstract class CoreFloatingWindow internal constructor(
@@ -52,7 +51,7 @@ public abstract class CoreFloatingWindow internal constructor(
         SupervisorJob() +
             coroutineContext + coroutineExceptionHandler,
     )
-    private val mutex = Mutex()
+    private val mainHandler = Handler(Looper.getMainLooper())
 
     public override val viewModelStore: ViewModelStore = ViewModelStore()
 
@@ -175,14 +174,13 @@ public abstract class CoreFloatingWindow internal constructor(
             // Set initial alpha to 0 for fade-in animation
             decorView.alpha = INVISIBLE_ALPHA
             windowManager.addView(decorView, windowParams)
+            // Move lifecycle to STARTED as soon as the view is attached. Lifecycle-aware Compose
+            // state collection and the lifecycle-aware recomposer both wait for STARTED.
+            lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
             // Animate fade-in
             decorView.animate()
                 .alpha(VISIBLE_ALPHA)
                 .setDuration(ANIMATION_DURATION)
-                .withEndAction {
-                    // Move lifecycle to STARTED only after view is successfully added
-                    lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
-                }
                 .start()
             // Update state last
             _isShowing.update { true }
@@ -222,21 +220,27 @@ public abstract class CoreFloatingWindow internal constructor(
      * @throws IllegalStateException if the window is already destroyed ([isDestroyed] is true).
      */
     public fun update() {
-        lifecycleCoroutineScope.launch {
-            checkDestroyed()
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            updateImmediately()
+        } else {
+            mainHandler.post {
+                updateImmediately()
+            }
+        }
+    }
 
-            if (!_isShowing.value) {
-                Log.w(tag, "Update called but window is not showing.")
-                return@launch
-            }
-            Log.d(tag, "Updating window layout.")
-            mutex.withLock {
-                try {
-                    windowManager.updateViewLayout(decorView, windowParams)
-                } catch (e: Exception) {
-                    Log.e(tag, "Error updating window layout: ${e.message}", e)
-                }
-            }
+    private fun updateImmediately() {
+        checkDestroyed()
+
+        if (!_isShowing.value) {
+            Log.w(tag, "Update called but window is not showing.")
+            return
+        }
+        Log.d(tag, "Updating window layout.")
+        try {
+            windowManager.updateViewLayout(decorView, windowParams)
+        } catch (e: Exception) {
+            Log.e(tag, "Error updating window layout: ${e.message}", e)
         }
     }
 

--- a/library/src/main/kotlin/com/github/only52607/compose/core/CoreFloatingWindow.kt
+++ b/library/src/main/kotlin/com/github/only52607/compose/core/CoreFloatingWindow.kt
@@ -46,12 +46,13 @@ public abstract class CoreFloatingWindow internal constructor(
     private val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
         Log.e(tag, "Coroutine Exception: ${throwable.message}", throwable)
     }
-    internal val coroutineContext = AndroidUiDispatcher.CurrentThread
+    internal val coroutineContext = AndroidUiDispatcher.Main
     internal val lifecycleCoroutineScope = CoroutineScope(
         SupervisorJob() +
             coroutineContext + coroutineExceptionHandler,
     )
     private val mainHandler = Handler(Looper.getMainLooper())
+    private var coordinateUpdateScheduled = false
 
     public override val viewModelStore: ViewModelStore = ViewModelStore()
 
@@ -202,14 +203,43 @@ public abstract class CoreFloatingWindow internal constructor(
      * @param top The new Y coordinate (top position) for the window.
      */
     public fun updateCoordinate(left: Int, top: Int) {
+        if (windowParams.x == left && windowParams.y == top) {
+            return
+        }
+
         windowParams.x = left
         windowParams.y = top
 
         try {
-            update()
+            scheduleCoordinateUpdate()
         } catch (e: Exception) {
             // Log but don't crash on update failures during drag
             Log.w(tag, "Failed to update window position: ${e.message}")
+        }
+    }
+
+    private fun scheduleCoordinateUpdate() {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            scheduleCoordinateUpdateOnMain()
+        } else {
+            mainHandler.post {
+                scheduleCoordinateUpdateOnMain()
+            }
+        }
+    }
+
+    private fun scheduleCoordinateUpdateOnMain() {
+        if (coordinateUpdateScheduled) {
+            return
+        }
+
+        coordinateUpdateScheduled = true
+        decorView.postOnAnimation {
+            coordinateUpdateScheduled = false
+            if (_isDestroyed.value) {
+                return@postOnAnimation
+            }
+            updateImmediately()
         }
     }
 

--- a/library/src/main/kotlin/com/github/only52607/compose/core/CoreFloatingWindow.kt
+++ b/library/src/main/kotlin/com/github/only52607/compose/core/CoreFloatingWindow.kt
@@ -275,7 +275,11 @@ public abstract class CoreFloatingWindow internal constructor(
         if (Looper.myLooper() == Looper.getMainLooper()) {
             updateImmediately()
         } else {
+            checkDestroyed()
             mainHandler.post {
+                if (_isDestroyed.value) {
+                    return@post
+                }
                 updateImmediately()
             }
         }
@@ -418,7 +422,16 @@ public abstract class CoreFloatingWindow internal constructor(
         // Hide the window if showing (ensures view is removed from WindowManager)
         if (_isShowing.value) {
             try {
-                hide()
+                _isShowing.update { false }
+                decorView.animate().cancel()
+
+                if (decorView.parent != null) {
+                    windowManager.removeViewImmediate(decorView)
+                } else {
+                    Log.w(tag, "Destroy called but DecorView has no parent.")
+                }
+
+                lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
             } catch (e: Exception) {
                 Log.e(
                     tag,

--- a/library/src/main/kotlin/com/github/only52607/compose/core/CoreFloatingWindow.kt
+++ b/library/src/main/kotlin/com/github/only52607/compose/core/CoreFloatingWindow.kt
@@ -177,6 +177,7 @@ public abstract class CoreFloatingWindow internal constructor(
             }
             // Set initial alpha to 0 for fade-in animation
             decorView.alpha = INVISIBLE_ALPHA
+            windowParams.disableSystemMoveAnimations()
             windowManager.addView(decorView, windowParams)
             // Move lifecycle to STARTED as soon as the view is attached. Lifecycle-aware Compose
             // state collection and the lifecycle-aware recomposer both wait for STARTED.
@@ -289,6 +290,7 @@ public abstract class CoreFloatingWindow internal constructor(
         }
         Log.d(tag, "Updating window layout.")
         try {
+            windowParams.disableSystemMoveAnimations()
             windowManager.updateViewLayout(decorView, windowParams)
         } catch (e: Exception) {
             Log.e(tag, "Error updating window layout: ${e.message}", e)

--- a/library/src/main/kotlin/com/github/only52607/compose/core/CoreFloatingWindow.kt
+++ b/library/src/main/kotlin/com/github/only52607/compose/core/CoreFloatingWindow.kt
@@ -89,7 +89,10 @@ public abstract class CoreFloatingWindow internal constructor(
      * The root view container for the floating window's content.
      * This is the view added to the WindowManager.
      */
-    public var decorView: ViewGroup = FrameLayout(context)
+    public var decorView: ViewGroup = FloatingWindowDecorView(
+        context = context,
+        onWindowSizeChanged = ::onDecorViewSizeChanged,
+    )
         .apply {
             // Important: Prevent clipping so shadows or elements outside bounds can be drawn
             clipChildren = false
@@ -119,7 +122,7 @@ public abstract class CoreFloatingWindow internal constructor(
      * @return The maximum X coordinate in pixels, or 0 if the window hasn't been measured yet.
      */
     public val maxXCoordinate: Int
-        get() = display.metrics.widthPixels - decorView.measuredWidth
+        get() = (display.metrics.widthPixels - decorView.measuredWidth).coerceAtLeast(0)
 
     /**
      * The maximum Y coordinate for the floating window.
@@ -131,7 +134,7 @@ public abstract class CoreFloatingWindow internal constructor(
      * @return The maximum Y coordinate in pixels, or 0 if the window hasn't been measured yet.
      */
     public val maxYCoordinate: Int
-        get() = display.metrics.heightPixels - decorView.measuredHeight
+        get() = (display.metrics.heightPixels - decorView.measuredHeight).coerceAtLeast(0)
 
     /**
      * Shows the floating window with a fade-in animation.
@@ -240,6 +243,24 @@ public abstract class CoreFloatingWindow internal constructor(
                 return@postOnAnimation
             }
             updateImmediately()
+        }
+    }
+
+    private fun onDecorViewSizeChanged() {
+        if (!_isShowing.value || _isDestroyed.value) {
+            return
+        }
+
+        // Some Android versions relayout WRAP_CONTENT overlay windows by moving the surface
+        // when the content size changes. Re-apply the stored top-start coordinates after the
+        // new size is known so expanding/collapsing Compose content does not jump on screen.
+        windowParams.x = windowParams.x.coerceIn(0, maxXCoordinate)
+        windowParams.y = windowParams.y.coerceIn(0, maxYCoordinate)
+
+        try {
+            scheduleCoordinateUpdate()
+        } catch (e: Exception) {
+            Log.w(tag, "Failed to update window after size change: ${e.message}")
         }
     }
 
@@ -455,5 +476,20 @@ public abstract class CoreFloatingWindow internal constructor(
          * Alpha value representing fully visible state.
          */
         private const val VISIBLE_ALPHA = 1f
+    }
+}
+
+private class FloatingWindowDecorView(
+    context: Context,
+    private val onWindowSizeChanged: () -> Unit,
+) : FrameLayout(context) {
+    override fun onSizeChanged(width: Int, height: Int, oldWidth: Int, oldHeight: Int) {
+        super.onSizeChanged(width, height, oldWidth, oldHeight)
+
+        if (oldWidth == 0 && oldHeight == 0) {
+            return
+        }
+
+        onWindowSizeChanged()
     }
 }

--- a/library/src/main/kotlin/com/github/only52607/compose/core/LayoutParams.kt
+++ b/library/src/main/kotlin/com/github/only52607/compose/core/LayoutParams.kt
@@ -52,6 +52,28 @@ internal fun defaultLayoutParams(context: Context) = WindowManager.LayoutParams(
     disableSystemMoveAnimations()
 }
 
+/**
+ * Disables platform move animations for floating-window relayouts.
+ *
+ * Issue https://github.com/ArthurKun21/compose-overlay-window/issues/23 was caused by Android 13/14
+ * animating the overlay surface from an earlier position when a moved [WindowManager.LayoutParams.WRAP_CONTENT]
+ * window changed size. A drag updates [x] and [y] through [WindowManager.updateViewLayout], then a later Compose
+ * resize triggers another relayout. With move animations enabled, the system can visually interpolate the surface
+ * from the previous committed position to the current one before applying the new size, which looks like the
+ * floating window jumps back and then moves forward.
+ *
+ * Android 14 exposes this behavior as [WindowManager.LayoutParams.setCanPlayMoveAnimation], documented with the
+ * `android:windowNoMoveAnimation` attribute:
+ * https://developer.android.com/reference/android/view/WindowManager.LayoutParams#setCanPlayMoveAnimation(boolean)
+ *
+ * Android 13 has the same underlying private flag but no public API. The fallback below sets
+ * `PRIVATE_FLAG_NO_MOVE_ANIMATION` best-effort via reflection, matching the framework source flag used by the public
+ * Android 14 API. If reflection is blocked, the library keeps working and only the platform move animation workaround
+ * is skipped.
+ *
+ * This is applied before both [WindowManager.addView] and [WindowManager.updateViewLayout] so it also covers caller
+ * supplied layout params, not just [defaultLayoutParams].
+ */
 internal fun WindowManager.LayoutParams.disableSystemMoveAnimations() {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
         setCanPlayMoveAnimation(false)
@@ -60,6 +82,12 @@ internal fun WindowManager.LayoutParams.disableSystemMoveAnimations() {
     }
 }
 
+/**
+ * Best-effort Android 13 compatibility path for `android:windowNoMoveAnimation` before the public setter existed.
+ *
+ * Source reference for the hidden flag:
+ * https://android.googlesource.com/platform/frameworks/base/+/android-13.0.0_r1/core/java/android/view/WindowManager.java
+ */
 private fun WindowManager.LayoutParams.disableSystemMoveAnimationsWithPrivateFlag() {
     try {
         val layoutParamsClass = WindowManager.LayoutParams::class.java
@@ -73,6 +101,10 @@ private fun WindowManager.LayoutParams.disableSystemMoveAnimationsWithPrivateFla
             privateFlagsField.getInt(this) or noMoveAnimationFlag,
         )
     } catch (_: ReflectiveOperationException) {
+        // The Android 13 fallback is best-effort: if the hidden field or flag is unavailable,
+        // keep the public floating-window behavior and only skip the no-move-animation workaround.
     } catch (_: RuntimeException) {
+        // Some OEM builds can expose the field but reject hidden/private API access at runtime.
+        // Ignore that as well so custom LayoutParams remain usable without crashing the app.
     }
 }

--- a/library/src/main/kotlin/com/github/only52607/compose/core/LayoutParams.kt
+++ b/library/src/main/kotlin/com/github/only52607/compose/core/LayoutParams.kt
@@ -48,4 +48,31 @@ internal fun defaultLayoutParams(context: Context) = WindowManager.LayoutParams(
         }
     }
     // If context is an Activity, the default window type associated with the activity is used.
+
+    disableSystemMoveAnimations()
+}
+
+internal fun WindowManager.LayoutParams.disableSystemMoveAnimations() {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        setCanPlayMoveAnimation(false)
+    } else {
+        disableSystemMoveAnimationsWithPrivateFlag()
+    }
+}
+
+private fun WindowManager.LayoutParams.disableSystemMoveAnimationsWithPrivateFlag() {
+    try {
+        val layoutParamsClass = WindowManager.LayoutParams::class.java
+        val privateFlagsField = layoutParamsClass.getField("privateFlags")
+        val noMoveAnimationFlag = layoutParamsClass
+            .getField("PRIVATE_FLAG_NO_MOVE_ANIMATION")
+            .getInt(null)
+
+        privateFlagsField.setInt(
+            this,
+            privateFlagsField.getInt(this) or noMoveAnimationFlag,
+        )
+    } catch (_: ReflectiveOperationException) {
+    } catch (_: RuntimeException) {
+    }
 }

--- a/library/src/main/kotlin/com/github/only52607/compose/service/ComposeServiceFloatingWindow.kt
+++ b/library/src/main/kotlin/com/github/only52607/compose/service/ComposeServiceFloatingWindow.kt
@@ -9,16 +9,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Recomposer
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.compositionContext
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.createLifecycleAwareWindowRecomposer
 import androidx.core.view.isNotEmpty
 import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.lifecycle.setViewTreeViewModelStoreOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.github.only52607.compose.core.CoreFloatingWindow
 import com.github.only52607.compose.core.defaultLayoutParams
-import com.github.only52607.compose.window.LocalFloatingWindow
-import kotlinx.coroutines.launch
-import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Manages a floating window that can display Jetpack Compose content overlaying other applications.
@@ -72,24 +70,15 @@ public class ComposeServiceFloatingWindow(
             setViewTreeLifecycleOwner(this@ComposeServiceFloatingWindow)
             setViewTreeViewModelStoreOwner(this@ComposeServiceFloatingWindow)
             setViewTreeSavedStateRegistryOwner(this@ComposeServiceFloatingWindow)
+            setViewCompositionStrategy(
+                ViewCompositionStrategy.DisposeOnLifecycleDestroyed(lifecycle),
+            )
 
-            // Create a Recomposer tied to the window's lifecycle scope
-            val recomposer = Recomposer(coroutineContext)
-            compositionContext = recomposer
+            // ComposeView is hosted directly by WindowManager, so install a lifecycle-aware
+            // recomposer instead of relying on an Activity window recomposer.
+            val recomposer = createLifecycleAwareWindowRecomposer(lifecycle = lifecycle)
+            setParentCompositionContext(recomposer)
             parentComposition = recomposer // Store for later disposal
-
-            // Launch the Recomposer
-            lifecycleCoroutineScope.launch {
-                try {
-                    recomposer.runRecomposeAndApplyChanges()
-                } catch (e: CancellationException) {
-                    Log.d(SERVICE_TAG, "Coroutine scope cancelled normally: ${e.message}")
-                } catch (e: Exception) {
-                    Log.e(SERVICE_TAG, "Recomposer error", e)
-                } finally {
-                    Log.d(SERVICE_TAG, "Recomposer job finished.")
-                }
-            }
 
             // Set the actual Composable content
             setContent {

--- a/library/src/main/kotlin/com/github/only52607/compose/service/ComposeServiceFloatingWindow.kt
+++ b/library/src/main/kotlin/com/github/only52607/compose/service/ComposeServiceFloatingWindow.kt
@@ -76,7 +76,10 @@ public class ComposeServiceFloatingWindow(
 
             // ComposeView is hosted directly by WindowManager, so install a lifecycle-aware
             // recomposer instead of relying on an Activity window recomposer.
-            val recomposer = createLifecycleAwareWindowRecomposer(lifecycle = lifecycle)
+            val recomposer = createLifecycleAwareWindowRecomposer(
+                coroutineContext = this@ComposeServiceFloatingWindow.coroutineContext,
+                lifecycle = lifecycle,
+            )
             setParentCompositionContext(recomposer)
             parentComposition = recomposer // Store for later disposal
 

--- a/library/src/main/kotlin/com/github/only52607/compose/window/ComposeFloatingWindow.kt
+++ b/library/src/main/kotlin/com/github/only52607/compose/window/ComposeFloatingWindow.kt
@@ -88,7 +88,10 @@ public class ComposeFloatingWindow(
 
             // ComposeView is hosted directly by WindowManager, so install a lifecycle-aware
             // recomposer instead of relying on an Activity window recomposer.
-            val recomposer = createLifecycleAwareWindowRecomposer(lifecycle = lifecycle)
+            val recomposer = createLifecycleAwareWindowRecomposer(
+                coroutineContext = this@ComposeFloatingWindow.coroutineContext,
+                lifecycle = lifecycle,
+            )
             setParentCompositionContext(recomposer)
             parentComposition = recomposer // Store for later disposal
 

--- a/library/src/main/kotlin/com/github/only52607/compose/window/ComposeFloatingWindow.kt
+++ b/library/src/main/kotlin/com/github/only52607/compose/window/ComposeFloatingWindow.kt
@@ -8,7 +8,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.Recomposer
 import androidx.compose.ui.platform.ComposeView
-import androidx.compose.ui.platform.compositionContext
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.platform.createLifecycleAwareWindowRecomposer
 import androidx.core.view.isNotEmpty
 import androidx.lifecycle.HasDefaultViewModelProviderFactory
 import androidx.lifecycle.SavedStateViewModelFactory
@@ -18,8 +19,6 @@ import androidx.lifecycle.setViewTreeViewModelStoreOwner
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.github.only52607.compose.core.CoreFloatingWindow
 import com.github.only52607.compose.core.defaultLayoutParams
-import kotlinx.coroutines.launch
-import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * Manages a floating window that can display Jetpack Compose content overlaying other applications.
@@ -83,24 +82,15 @@ public class ComposeFloatingWindow(
             setViewTreeLifecycleOwner(this@ComposeFloatingWindow)
             setViewTreeViewModelStoreOwner(this@ComposeFloatingWindow)
             setViewTreeSavedStateRegistryOwner(this@ComposeFloatingWindow)
+            setViewCompositionStrategy(
+                ViewCompositionStrategy.DisposeOnLifecycleDestroyed(lifecycle),
+            )
 
-            // Create a Recomposer tied to the window's lifecycle scope
-            val recomposer = Recomposer(coroutineContext)
-            compositionContext = recomposer
+            // ComposeView is hosted directly by WindowManager, so install a lifecycle-aware
+            // recomposer instead of relying on an Activity window recomposer.
+            val recomposer = createLifecycleAwareWindowRecomposer(lifecycle = lifecycle)
+            setParentCompositionContext(recomposer)
             parentComposition = recomposer // Store for later disposal
-
-            // Launch the Recomposer
-            lifecycleCoroutineScope.launch {
-                try {
-                    recomposer.runRecomposeAndApplyChanges()
-                } catch (e: CancellationException) {
-                    Log.d(TAG, "Coroutine scope cancelled normally: ${e.message}")
-                } catch (e: Exception) {
-                    Log.e(TAG, "Recomposer error", e)
-                } finally {
-                    Log.d(TAG, "Recomposer job finished.")
-                }
-            }
 
             // Set the actual Composable content
             setContent {


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [ ] Chore
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->
- Closes #23

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
Fixes a floating window positioning bug on Android 13/14 where a `WRAP_CONTENT` overlay could visually move from its previous location after being dragged and then resized.

The root cause is Android's platform move animation for window relayouts. After the floating window is dragged, a later content-size change triggers another `WindowManager.updateViewLayout(...)`. On affected Android versions, the system can animate the overlay surface from the previous committed position to the new position before applying the resized content, making the window appear to jump.

This PR fixes that by:

- Disabling platform move animations for floating-window layout params.
  - Android 14+ uses `WindowManager.LayoutParams.setCanPlayMoveAnimation(false)`.
  - Android 13 uses a guarded best-effort fallback for the underlying private no-move-animation flag.
- Re-applying the workaround before both `addView(...)` and `updateViewLayout(...)`, so it also covers caller-provided `LayoutParams`.
- Keeping the fallback non-fatal if reflection is unavailable or blocked on OEM builds.
- Adding KDocs explaining the Android 13/14 behavior, the issue, and the relevant Android framework APIs.

The PR also keeps the floating window update path on the main thread and schedules coordinate updates on the next frame to avoid excessive layout updates during drag.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->
Tested manually on a physical Android 14 device using the reproduction from #23:

1. Initialize the floating window.
2. Call `show()`.
3. Tap the floating window to resize it.
4. Drag the floating window to a new location.
5. Tap again to resize.

Before this fix, the floating window animated from its old location to the new location before resizing. After this fix, the floating window resizes in place without the unexpected move animation.

## Additional context
<!-- Add any other context about the pull request here. -->


- `WindowManager.LayoutParams.setCanPlayMoveAnimation(false)`:
  https://developer.android.com/reference/android/view/WindowManager.LayoutParams#setCanPlayMoveAnimation(boolean)

Issue context:

- https://github.com/ArthurKun21/compose-overlay-window/issues/23