### PR TITLE
fix: library regressions

### DIFF
--- a/library/src/androidTest/java/com/github/only52607/compose/window/FloatingWindowInstrumentedTest.kt
+++ b/library/src/androidTest/java/com/github/only52607/compose/window/FloatingWindowInstrumentedTest.kt
@@ -1,11 +1,17 @@
 package com.github.only52607.compose.window
 
+import android.content.Context
+import android.content.ContextWrapper
 import android.os.ParcelFileDescriptor
+import android.view.View
+import android.view.ViewGroup
+import android.view.WindowManager
 import androidx.compose.material3.Text
 import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.MotionDurationScale
 import androidx.lifecycle.Lifecycle
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
@@ -95,6 +101,22 @@ class FloatingWindowInstrumentedTest {
     }
 
     @Test
+    fun recomposerUsesSystemMotionDurationScale() {
+        val window = newWindow()
+
+        instrumentation.runOnMainSync {
+            window.setContent {
+                Text("Ready")
+            }
+
+            assertTrue(
+                "Floating window recomposer should respect the system animation duration scale.",
+                window.parentComposition?.effectCoroutineContext?.get(MotionDurationScale) != null,
+            )
+        }
+    }
+
+    @Test
     fun composeContentRecomposesAfterHideAndShow() {
         val window = newWindow()
         var label by mutableStateOf("Before")
@@ -156,10 +178,33 @@ class FloatingWindowInstrumentedTest {
         }
     }
 
-    private fun newWindow(): ComposeServiceFloatingWindow {
+    @Test
+    fun showDuringHideReappliesWindowParams() {
+        val recordingContext = RecordingWindowManagerContext(context)
+        val window = newWindow(recordingContext)
+
+        instrumentation.runOnMainSync {
+            window.setContent {
+                Text("Ready")
+            }
+            window.show()
+
+            val updateCallsBeforeReshow = recordingContext.windowManager.updateViewLayoutCalls
+            window.hide()
+            window.windowParams.x += 100
+            window.show()
+
+            assertTrue(
+                "Re-showing an attached window should reapply its updated layout parameters.",
+                recordingContext.windowManager.updateViewLayoutCalls > updateCallsBeforeReshow,
+            )
+        }
+    }
+
+    private fun newWindow(windowContext: Context = context): ComposeServiceFloatingWindow {
         lateinit var window: ComposeServiceFloatingWindow
         instrumentation.runOnMainSync {
-            window = ComposeServiceFloatingWindow(context)
+            window = ComposeServiceFloatingWindow(windowContext)
             windows += window
             assertTrue(
                 "SYSTEM_ALERT_WINDOW app-op was not granted for the test package.",
@@ -197,5 +242,29 @@ class FloatingWindowInstrumentedTest {
         const val TIMEOUT_SECONDS = 3L
         const val ANIMATION_SETTLE_MILLIS = 500L
         const val POLL_INTERVAL_MILLIS = 20L
+    }
+}
+
+private class RecordingWindowManagerContext(base: Context) : ContextWrapper(base) {
+    val windowManager = RecordingWindowManager(
+        base.getSystemService(Context.WINDOW_SERVICE) as WindowManager,
+    )
+
+    override fun getSystemService(name: String): Any? = if (name == Context.WINDOW_SERVICE) {
+        windowManager
+    } else {
+        super.getSystemService(name)
+    }
+}
+
+private class RecordingWindowManager(
+    private val delegate: WindowManager,
+) : WindowManager by delegate {
+    var updateViewLayoutCalls: Int = 0
+        private set
+
+    override fun updateViewLayout(view: View, params: ViewGroup.LayoutParams) {
+        updateViewLayoutCalls++
+        delegate.updateViewLayout(view, params)
     }
 }

--- a/library/src/androidTest/java/com/github/only52607/compose/window/FloatingWindowInstrumentedTest.kt
+++ b/library/src/androidTest/java/com/github/only52607/compose/window/FloatingWindowInstrumentedTest.kt
@@ -119,6 +119,33 @@ class FloatingWindowInstrumentedTest {
     }
 
     @Test
+    fun recomposerObservesSystemMotionDurationScaleChanges() {
+        val window = newWindow()
+        lateinit var motionDurationScale: MotionDurationScale
+
+        instrumentation.runOnMainSync {
+            window.setContent {
+                Text("Ready")
+            }
+            motionDurationScale = requireNotNull(
+                window.parentComposition?.effectCoroutineContext?.get(MotionDurationScale),
+            )
+        }
+
+        val originalScale = executeShellCommand("settings get global animator_duration_scale")
+            .trim()
+            .toFloatOrNull() ?: 1f
+        val updatedScale = if (originalScale == 0f) 1f else 0f
+
+        try {
+            executeShellCommand("settings put global animator_duration_scale $updatedScale")
+            waitUntilMotionDurationScaleEquals(motionDurationScale, updatedScale)
+        } finally {
+            executeShellCommand("settings put global animator_duration_scale $originalScale")
+        }
+    }
+
+    @Test
     fun composeContentRecomposesAfterHideAndShow() {
         val window = newWindow()
         var label by mutableStateOf("Before")
@@ -234,10 +261,32 @@ class FloatingWindowInstrumentedTest {
         }
     }
 
-    private fun executeShellCommand(command: String) {
+    private fun waitUntilMotionDurationScaleEquals(
+        motionDurationScale: MotionDurationScale,
+        expectedScale: Float,
+    ) {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(TIMEOUT_SECONDS)
+        while (System.nanoTime() < deadline) {
+            if (motionDurationScale.scaleFactor == expectedScale) {
+                return
+            }
+            Thread.sleep(POLL_INTERVAL_MILLIS)
+        }
+
+        assertEquals(
+            "Floating window recomposer did not observe the animator duration scale change.",
+            expectedScale,
+            motionDurationScale.scaleFactor,
+        )
+    }
+
+    private fun executeShellCommand(command: String): String {
         val descriptor: ParcelFileDescriptor = instrumentation.uiAutomation.executeShellCommand(command)
-        FileInputStream(descriptor.fileDescriptor).bufferedReader().use { it.readText() }
-        descriptor.close()
+        return try {
+            FileInputStream(descriptor.fileDescriptor).bufferedReader().use { it.readText() }
+        } finally {
+            descriptor.close()
+        }
     }
 
     private companion object {

--- a/library/src/androidTest/java/com/github/only52607/compose/window/FloatingWindowInstrumentedTest.kt
+++ b/library/src/androidTest/java/com/github/only52607/compose/window/FloatingWindowInstrumentedTest.kt
@@ -17,6 +17,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.only52607.compose.service.ComposeServiceFloatingWindow
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
@@ -49,7 +50,7 @@ class FloatingWindowInstrumentedTest {
     }
 
     @Test
-    fun showMovesLifecycleToStartedImmediately() {
+    fun showMovesLifecycleToResumedImmediately() {
         val window = newWindow()
 
         instrumentation.runOnMainSync {
@@ -59,9 +60,10 @@ class FloatingWindowInstrumentedTest {
             window.show()
         }
 
-        assertTrue(
-            "Floating window lifecycle should be STARTED immediately after show().",
-            window.lifecycle.currentState.isAtLeast(Lifecycle.State.STARTED),
+        assertEquals(
+            "Floating window lifecycle should be RESUMED immediately after show().",
+            Lifecycle.State.RESUMED,
+            window.lifecycle.currentState,
         )
     }
 

--- a/library/src/androidTest/java/com/github/only52607/compose/window/FloatingWindowInstrumentedTest.kt
+++ b/library/src/androidTest/java/com/github/only52607/compose/window/FloatingWindowInstrumentedTest.kt
@@ -11,6 +11,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
 import com.github.only52607.compose.service.ComposeServiceFloatingWindow
 import org.junit.After
+import org.junit.Assert.assertFalse
 import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
@@ -93,6 +94,68 @@ class FloatingWindowInstrumentedTest {
         )
     }
 
+    @Test
+    fun composeContentRecomposesAfterHideAndShow() {
+        val window = newWindow()
+        var label by mutableStateOf("Before")
+        val initialComposition = CountDownLatch(1)
+        val updatedComposition = CountDownLatch(1)
+
+        instrumentation.runOnMainSync {
+            window.setContent {
+                Text(text = label)
+                SideEffect {
+                    when (label) {
+                        "Before" -> initialComposition.countDown()
+                        "After" -> updatedComposition.countDown()
+                    }
+                }
+            }
+            window.show()
+        }
+
+        assertTrue(
+            "Initial floating window composition did not run.",
+            initialComposition.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+        )
+
+        instrumentation.runOnMainSync {
+            window.hide()
+        }
+        waitUntilDetached(window)
+
+        instrumentation.runOnMainSync {
+            window.show()
+            label = "After"
+        }
+
+        assertTrue(
+            "Floating window did not recompose after being hidden and shown again.",
+            updatedComposition.await(TIMEOUT_SECONDS, TimeUnit.SECONDS),
+        )
+    }
+
+    @Test
+    fun showDuringHideKeepsWindowAttached() {
+        val window = newWindow()
+
+        instrumentation.runOnMainSync {
+            window.setContent {
+                Text("Ready")
+            }
+            window.show()
+            window.hide()
+            window.show()
+        }
+
+        Thread.sleep(ANIMATION_SETTLE_MILLIS)
+
+        instrumentation.runOnMainSync {
+            assertTrue("Window should still be showing.", window.isShowing.value)
+            assertTrue("Window should still be attached.", window.decorView.isAttachedToWindow)
+        }
+    }
+
     private fun newWindow(): ComposeServiceFloatingWindow {
         lateinit var window: ComposeServiceFloatingWindow
         instrumentation.runOnMainSync {
@@ -106,6 +169,24 @@ class FloatingWindowInstrumentedTest {
         return window
     }
 
+    private fun waitUntilDetached(window: ComposeServiceFloatingWindow) {
+        val deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(TIMEOUT_SECONDS)
+        while (System.nanoTime() < deadline) {
+            var isAttached = true
+            instrumentation.runOnMainSync {
+                isAttached = window.decorView.isAttachedToWindow
+            }
+            if (!isAttached) {
+                return
+            }
+            Thread.sleep(POLL_INTERVAL_MILLIS)
+        }
+
+        instrumentation.runOnMainSync {
+            assertFalse("Floating window did not detach after hide().", window.decorView.isAttachedToWindow)
+        }
+    }
+
     private fun executeShellCommand(command: String) {
         val descriptor: ParcelFileDescriptor = instrumentation.uiAutomation.executeShellCommand(command)
         FileInputStream(descriptor.fileDescriptor).bufferedReader().use { it.readText() }
@@ -114,5 +195,7 @@ class FloatingWindowInstrumentedTest {
 
     private companion object {
         const val TIMEOUT_SECONDS = 3L
+        const val ANIMATION_SETTLE_MILLIS = 500L
+        const val POLL_INTERVAL_MILLIS = 20L
     }
 }

--- a/library/src/main/kotlin/com/github/only52607/compose/core/CoreFloatingWindow.kt
+++ b/library/src/main/kotlin/com/github/only52607/compose/core/CoreFloatingWindow.kt
@@ -40,6 +40,22 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.coroutines.cancellation.CancellationException
 
+/**
+ * Base owner for a Compose hierarchy hosted directly by [WindowManager].
+ *
+ * A window starts in [Lifecycle.State.CREATED]. [show] attaches [decorView], sets [isShowing] to
+ * `true`, and advances the lifecycle to [Lifecycle.State.RESUMED] while the screen is interactive.
+ * [hide] immediately sets [isShowing] to `false` and returns the lifecycle to
+ * [Lifecycle.State.CREATED], then detaches the view after its fade-out animation. Turning the
+ * screen off applies the same lifecycle transition to a shown window; turning it on resumes that
+ * window.
+ *
+ * Hiding or temporarily detaching the view does not dispose its composition. The window owns its
+ * recomposer across detach/reattach cycles, pauses frame-driven effects while stopped, and honors
+ * the system animator-duration scale. Call [close] when the window is no longer needed to detach
+ * it immediately, dispose its composition, destroy its lifecycle and ViewModels, and release
+ * registered observers and receivers. A closed instance cannot be shown again.
+ */
 public abstract class CoreFloatingWindow internal constructor(
     private val context: Context,
     private val tag: String = "CoreFloatingWindow",
@@ -49,6 +65,12 @@ public abstract class CoreFloatingWindow internal constructor(
 
     private val applicationContext = context.applicationContext
 
+    /**
+     * Layout parameters used when attaching or updating this window.
+     *
+     * Changes made while the window is visible take effect after calling [update]. Changes made
+     * while hidden are applied by the next [show].
+     */
     public abstract val windowParams: WindowManager.LayoutParams
 
     // --- Lifecycle, ViewModel, SavedState ---
@@ -78,8 +100,14 @@ public abstract class CoreFloatingWindow internal constructor(
     private val _isShowing = MutableStateFlow(false)
 
     /**
-     * A [StateFlow] indicating whether the floating window is currently shown (`true`) or hidden (`false`).
-     * Does not reflect the destroyed state. Check [isDestroyed] for that.
+     * Whether this window is logically shown.
+     *
+     * The value becomes `true` when [show] successfully attaches or reuses the window and becomes
+     * `false` as soon as [hide] starts. During the fade-out animation, the value is already `false`
+     * even though [decorView] may remain attached briefly. This state is independent of screen
+     * interactivity; a shown window remains `true` while its lifecycle is stopped for screen-off.
+     *
+     * This does not indicate whether the instance has been closed. Check [isDestroyed] for that.
      */
     public val isShowing: StateFlow<Boolean>
         get() = _isShowing.asStateFlow()
@@ -87,15 +115,18 @@ public abstract class CoreFloatingWindow internal constructor(
     private val _isDestroyed = MutableStateFlow(false)
 
     /**
-     * A [StateFlow] indicating whether the floating window has been destroyed (`true`).
-     * Once destroyed, the instance cannot be reused. Create a new instance if needed.
+     * Whether [close] has permanently destroyed this window.
+     *
+     * Once this becomes `true`, the instance cannot be reused. Create a new window instead.
      */
     public val isDestroyed: StateFlow<Boolean>
         get() = _isDestroyed.asStateFlow()
 
     /**
      * The root view container for the floating window's content.
-     * This is the view added to the WindowManager.
+     *
+     * This view is attached directly to [WindowManager] by [show] and detached by [hide] or
+     * [close]. Its Compose content and recomposer survive a normal [hide]/[show] cycle.
      */
     public var decorView: ViewGroup = FloatingWindowDecorView(
         context = context,
@@ -188,12 +219,16 @@ public abstract class CoreFloatingWindow internal constructor(
     /**
      * Shows the floating window with a fade-in animation.
      *
-     * Adds the [decorView] to the [WindowManager] using the configured [windowParams].
-     * Moves the lifecycle state to RESUMED.
-     * Requires the `SYSTEM_ALERT_WINDOW` permission.
+     * Attaches [decorView] to [WindowManager] with [windowParams], or reuses it if [hide]'s
+     * fade-out is still in progress. When the screen is interactive, the lifecycle advances to
+     * [Lifecycle.State.RESUMED]; otherwise it remains [Lifecycle.State.CREATED] until screen-on.
+     * Calling this while already shown reapplies [windowParams].
+     *
+     * This operation requires the `SYSTEM_ALERT_WINDOW` permission. If the permission is absent,
+     * the call logs a warning and leaves the window hidden.
      *
      * @throws IllegalStateException if the window is already destroyed ([isDestroyed] is true).
-     * @throws SecurityException if the `SYSTEM_ALERT_WINDOW` permission is not granted (logged as warning).
+     * @throws IllegalArgumentException if Compose content has not been provided by a subclass.
      */
     public fun show() {
         checkDestroyed()
@@ -263,8 +298,9 @@ public abstract class CoreFloatingWindow internal constructor(
     /**
      * Updates the window coordinates to the specified position.
      *
-     * This method updates the window parameters with new coordinates and followed
-     * by a call to [update] to apply the changes to the displayed window.
+     * Stores the coordinates in [windowParams] and coalesces visible-window updates onto the next
+     * animation frame. If the window is hidden, the stored coordinates are used by the next
+     * [show].
      *
      * @param left The new X coordinate (left position) for the window.
      * @param top The new Y coordinate (top position) for the window.
@@ -334,7 +370,10 @@ public abstract class CoreFloatingWindow internal constructor(
 
     /**
      * Updates the layout of the floating window using the current [windowParams].
-     * Call this after modifying [windowParams] (e.g., position or size) while the window is showing.
+     *
+     * Call this after modifying [windowParams] (for example, its position or size) while the
+     * window is showing. Calls made while hidden do not attach or update the window; the parameters
+     * are applied by the next [show]. Calls from a background thread are posted to the main thread.
      *
      * @throws IllegalStateException if the window is already destroyed ([isDestroyed] is true).
      */
@@ -371,8 +410,11 @@ public abstract class CoreFloatingWindow internal constructor(
     /**
      * Hides the floating window with fade-out animation.
      *
-     * Removes the [decorView] from the [WindowManager].
-     * Moves the lifecycle state to STOPPED.
+     * Sets [isShowing] to `false` immediately, dispatches lifecycle pause/stop events so the
+     * lifecycle returns to [Lifecycle.State.CREATED], and removes [decorView] from [WindowManager]
+     * when the animation finishes. The composition is retained and can be resumed by [show]. If
+     * [show] is called before the fade-out finishes, removal is cancelled and the existing view is
+     * reused.
      *
      * @throws IllegalStateException if the window is already destroyed ([isDestroyed] is true).
      */
@@ -519,18 +561,17 @@ public abstract class CoreFloatingWindow internal constructor(
 
     /**
      * Implementation of [AutoCloseable].
-     * Destroys the floating window, releasing all associated resources.
+     * Permanently destroys the floating window and releases its resources.
      *
      * This performs the following actions:
-     * 1. Hides the window if it is currently showing.
-     * 2. Disposes the Jetpack Compose composition.
-     * 3. Cancels all coroutines launched in the window's lifecycle scope.
-     * 4. Moves the lifecycle state to DESTROYED.
-     * 5. Clears the [ViewModelStore], destroying associated ViewModels.
-     * 6. Cleans up internal references.
+     * 1. Unregisters the screen-state receiver.
+     * 2. Cancels any fade animation and detaches [decorView] immediately.
+     * 3. Disposes the Compose composition and its window-owned recomposer.
+     * 4. Cancels window-owned coroutines and animation-scale observation.
+     * 5. Moves the lifecycle to [Lifecycle.State.DESTROYED].
+     * 6. Clears the [ViewModelStore], destroying associated ViewModels.
      *
-     * **Once destroyed, this instance cannot be reused.** Create a new `FloatingWindow`
-     * instance if you need to show a floating window again.
+     * Repeated calls are ignored. Once destroyed, this instance cannot be reused.
      */
     public override fun close() {
         if (_isDestroyed.value) {

--- a/library/src/main/kotlin/com/github/only52607/compose/core/CoreFloatingWindow.kt
+++ b/library/src/main/kotlin/com/github/only52607/compose/core/CoreFloatingWindow.kt
@@ -47,6 +47,8 @@ public abstract class CoreFloatingWindow internal constructor(
     ViewModelStoreOwner,
     AutoCloseable {
 
+    private val applicationContext = context.applicationContext
+
     public abstract val windowParams: WindowManager.LayoutParams
 
     // --- Lifecycle, ViewModel, SavedState ---
@@ -115,14 +117,18 @@ public abstract class CoreFloatingWindow internal constructor(
     // animations) must stop. Otherwise the window keeps composing/measuring into an invisible
     // surface while the screen is off, and the accumulated work bursts onto the first frames
     // after the screen turns back on, which is felt as lag.
-    private var isScreenInteractive =
-        (context.getSystemService(Context.POWER_SERVICE) as? PowerManager)?.isInteractive ?: true
+    private val powerManager =
+        applicationContext.getSystemService(Context.POWER_SERVICE) as? PowerManager
+    private val isScreenInteractive: Boolean
+        get() = powerManager?.isInteractive ?: true
 
     private val screenStateReceiver = object : BroadcastReceiver() {
         override fun onReceive(receiverContext: Context?, intent: Intent?) {
             when (intent?.action) {
-                Intent.ACTION_SCREEN_ON -> isScreenInteractive = true
-                Intent.ACTION_SCREEN_OFF -> isScreenInteractive = false
+                Intent.ACTION_SCREEN_ON,
+                Intent.ACTION_SCREEN_OFF,
+                -> Unit
+
                 else -> return
             }
             Log.d(tag, "Screen interactive: $isScreenInteractive")
@@ -447,7 +453,7 @@ public abstract class CoreFloatingWindow internal constructor(
         // screen is off. ACTION_SCREEN_ON/OFF are protected system broadcasts, so the receiver
         // does not need to be exported.
         ContextCompat.registerReceiver(
-            context,
+            applicationContext,
             screenStateReceiver,
             IntentFilter().apply {
                 addAction(Intent.ACTION_SCREEN_ON)
@@ -467,7 +473,7 @@ public abstract class CoreFloatingWindow internal constructor(
 
     /** Creates a recomposer owned by this window rather than by a single view attachment. */
     internal fun createWindowRecomposer(): Recomposer {
-        val motionDurationScale = SystemMotionDurationScale(context.applicationContext)
+        val motionDurationScale = SystemMotionDurationScale(applicationContext)
         val recomposer = Recomposer(coroutineContext + motionDurationScale)
 
         // Mirror androidx's lifecycle-aware window recomposer: keep the composition frame clock
@@ -534,7 +540,7 @@ public abstract class CoreFloatingWindow internal constructor(
         Log.d(tag, "Destroying window...")
 
         try {
-            context.unregisterReceiver(screenStateReceiver)
+            applicationContext.unregisterReceiver(screenStateReceiver)
         } catch (e: IllegalArgumentException) {
             Log.w(tag, "Screen state receiver was not registered: ${e.message}")
         }

--- a/library/src/main/kotlin/com/github/only52607/compose/core/CoreFloatingWindow.kt
+++ b/library/src/main/kotlin/com/github/only52607/compose/core/CoreFloatingWindow.kt
@@ -143,7 +143,7 @@ public abstract class CoreFloatingWindow internal constructor(
      * Shows the floating window with a fade-in animation.
      *
      * Adds the [decorView] to the [WindowManager] using the configured [windowParams].
-     * Moves the lifecycle state to STARTED.
+     * Moves the lifecycle state to RESUMED.
      * Requires the `SYSTEM_ALERT_WINDOW` permission.
      *
      * @throws IllegalStateException if the window is already destroyed ([isDestroyed] is true).
@@ -194,9 +194,11 @@ public abstract class CoreFloatingWindow internal constructor(
                 _isShowing.update { true }
             }
 
-            // Move lifecycle to STARTED as soon as the view is attached. Lifecycle-aware Compose
-            // state collection waits for STARTED.
-            lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
+            // Move lifecycle to RESUMED as soon as the view is attached (delivers ON_START and
+            // ON_RESUME in order). A shown floating window is the overlay equivalent of a resumed
+            // Activity: lifecycle-aware collection such as collectAsStateWithLifecycle or
+            // repeatOnLifecycle gated on STARTED or RESUMED must be active while it is visible.
+            lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
             // Animate fade-in
             decorView.animate()
                 .alpha(VISIBLE_ALPHA)
@@ -415,7 +417,21 @@ public abstract class CoreFloatingWindow internal constructor(
         // recomposer treats that detach as permanent destruction, so own the runner here and
         // cancel it only when content is replaced or this floating window is closed.
         lifecycleCoroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
-            recomposer.runRecomposeAndApplyChanges()
+            try {
+                recomposer.runRecomposeAndApplyChanges()
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                // An exception thrown by recomposition or an effect terminates the recomposer.
+                // Without this log the only visible symptom is a floating window whose UI
+                // silently stops updating, so make the failure mode explicit.
+                Log.e(
+                    tag,
+                    "Recomposer terminated unexpectedly. This floating window's Compose UI " +
+                        "will no longer update. Call setContent() again to recover.",
+                    e,
+                )
+            }
         }
     }
 

--- a/library/src/main/kotlin/com/github/only52607/compose/core/CoreFloatingWindow.kt
+++ b/library/src/main/kotlin/com/github/only52607/compose/core/CoreFloatingWindow.kt
@@ -5,6 +5,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.database.ContentObserver
 import android.os.Handler
 import android.os.Looper
 import android.os.PowerManager
@@ -15,6 +16,7 @@ import android.view.ViewGroup
 import android.view.WindowManager
 import android.widget.FrameLayout
 import androidx.compose.runtime.Recomposer
+import androidx.compose.ui.MotionDurationScale
 import androidx.compose.ui.platform.AndroidUiDispatcher
 import androidx.compose.ui.platform.ComposeView
 import androidx.core.content.ContextCompat
@@ -27,7 +29,6 @@ import androidx.lifecycle.enableSavedStateHandles
 import androidx.savedstate.SavedStateRegistry
 import androidx.savedstate.SavedStateRegistryController
 import androidx.savedstate.SavedStateRegistryOwner
-import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.SupervisorJob
@@ -52,13 +53,9 @@ public abstract class CoreFloatingWindow internal constructor(
 
     // Use a SupervisorJob so failure of one child doesn't cause others to fail
     // Use a custom scope tied to the window's lifecycle for managing window-specific coroutines
-    private val coroutineExceptionHandler = CoroutineExceptionHandler { _, throwable ->
-        Log.e(tag, "Coroutine Exception: ${throwable.message}", throwable)
-    }
     internal val coroutineContext = AndroidUiDispatcher.Main
     internal val lifecycleCoroutineScope = CoroutineScope(
-        SupervisorJob() +
-            coroutineContext + coroutineExceptionHandler,
+        SupervisorJob() + coroutineContext,
     )
     private val mainHandler = Handler(Looper.getMainLooper())
     private var coordinateUpdateScheduled = false
@@ -228,6 +225,7 @@ public abstract class CoreFloatingWindow internal constructor(
                 // animator so its removal callback cannot detach the view we are reusing.
                 _isShowing.update { true }
                 decorView.animate().cancel()
+                updateImmediately()
             } else {
                 // A frame callback posted before the previous detach may have been discarded.
                 coordinateUpdateScheduled = false
@@ -468,7 +466,10 @@ public abstract class CoreFloatingWindow internal constructor(
     }
 
     /** Creates a recomposer owned by this window rather than by a single view attachment. */
-    internal fun createWindowRecomposer(): Recomposer = Recomposer(coroutineContext).also { recomposer ->
+    internal fun createWindowRecomposer(): Recomposer {
+        val motionDurationScale = SystemMotionDurationScale(context.applicationContext)
+        val recomposer = Recomposer(coroutineContext + motionDurationScale)
+
         // Mirror androidx's lifecycle-aware window recomposer: keep the composition frame clock
         // (which drives withFrameNanos-based animations) paused while the window is not STARTED,
         // i.e. while it is hidden or the screen is off. Recomposition from state changes still
@@ -489,22 +490,13 @@ public abstract class CoreFloatingWindow internal constructor(
         lifecycleCoroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
             try {
                 recomposer.runRecomposeAndApplyChanges()
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                // An exception thrown by recomposition or an effect terminates the recomposer.
-                // Without this log the only visible symptom is a floating window whose UI
-                // silently stops updating, so make the failure mode explicit.
-                Log.e(
-                    tag,
-                    "Recomposer terminated unexpectedly. This floating window's Compose UI " +
-                        "will no longer update. Call setContent() again to recover.",
-                    e,
-                )
             } finally {
                 lifecycle.removeObserver(frameClockObserver)
+                motionDurationScale.close()
             }
         }
+
+        return recomposer
     }
 
     /** Disposes the Compose composition and clears the reference. */
@@ -637,5 +629,39 @@ private class FloatingWindowDecorView(
         }
 
         onWindowSizeChanged()
+    }
+}
+
+private class SystemMotionDurationScale(context: Context) : MotionDurationScale, AutoCloseable {
+    private val contentResolver = context.contentResolver
+    private val animationScaleUri =
+        Settings.Global.getUriFor(Settings.Global.ANIMATOR_DURATION_SCALE)
+
+    @Volatile
+    override var scaleFactor: Float = readScaleFactor()
+        private set
+
+    private val observer = object : ContentObserver(Handler(Looper.getMainLooper())) {
+        override fun onChange(selfChange: Boolean) {
+            scaleFactor = readScaleFactor()
+        }
+    }
+
+    init {
+        contentResolver.registerContentObserver(animationScaleUri, false, observer)
+    }
+
+    private fun readScaleFactor(): Float = Settings.Global.getFloat(
+        contentResolver,
+        Settings.Global.ANIMATOR_DURATION_SCALE,
+        DEFAULT_SCALE_FACTOR,
+    )
+
+    override fun close() {
+        contentResolver.unregisterContentObserver(observer)
+    }
+
+    private companion object {
+        const val DEFAULT_SCALE_FACTOR = 1f
     }
 }

--- a/library/src/main/kotlin/com/github/only52607/compose/core/CoreFloatingWindow.kt
+++ b/library/src/main/kotlin/com/github/only52607/compose/core/CoreFloatingWindow.kt
@@ -6,6 +6,7 @@ import android.os.Handler
 import android.os.Looper
 import android.provider.Settings
 import android.util.Log
+import android.view.Gravity
 import android.view.ViewGroup
 import android.view.WindowManager
 import android.widget.FrameLayout
@@ -22,12 +23,14 @@ import androidx.savedstate.SavedStateRegistryController
 import androidx.savedstate.SavedStateRegistryOwner
 import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
 import kotlin.coroutines.cancellation.CancellationException
 
 public abstract class CoreFloatingWindow internal constructor(
@@ -170,25 +173,35 @@ public abstract class CoreFloatingWindow internal constructor(
         Log.d(tag, "Showing window.")
 
         try {
-            // Ensure the view doesn't have a parent before adding
-            if (decorView.parent != null) {
-                Log.w(tag, "DecorView already has a parent. Removing it.")
-                (decorView.parent as? ViewGroup)?.removeView(decorView)
+            val parent = decorView.parent
+            val isAttachedToWindowManager = parent != null && parent !is ViewGroup
+            if (parent is ViewGroup) {
+                Log.w(tag, "DecorView already has a ViewGroup parent. Removing it.")
+                parent.removeView(decorView)
             }
-            // Set initial alpha to 0 for fade-in animation
-            decorView.alpha = INVISIBLE_ALPHA
-            windowParams.disableSystemMoveAnimations()
-            windowManager.addView(decorView, windowParams)
+
+            if (isAttachedToWindowManager) {
+                // hide() is still fading out. Mark the window as showing before cancelling the
+                // animator so its removal callback cannot detach the view we are reusing.
+                _isShowing.update { true }
+                decorView.animate().cancel()
+            } else {
+                // A frame callback posted before the previous detach may have been discarded.
+                coordinateUpdateScheduled = false
+                decorView.alpha = INVISIBLE_ALPHA
+                windowParams.disableSystemMoveAnimations()
+                windowManager.addView(decorView, windowParams)
+                _isShowing.update { true }
+            }
+
             // Move lifecycle to STARTED as soon as the view is attached. Lifecycle-aware Compose
-            // state collection and the lifecycle-aware recomposer both wait for STARTED.
+            // state collection waits for STARTED.
             lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_START)
             // Animate fade-in
             decorView.animate()
                 .alpha(VISIBLE_ALPHA)
                 .setDuration(ANIMATION_DURATION)
                 .start()
-            // Update state last
-            _isShowing.update { true }
         } catch (e: Exception) {
             // Catch potential exceptions from WindowManager (e.g., security, bad token)
             Log.e(tag, "Error showing window: ${e.message}", e)
@@ -255,8 +268,12 @@ public abstract class CoreFloatingWindow internal constructor(
         // Some Android versions relayout WRAP_CONTENT overlay windows by moving the surface
         // when the content size changes. Re-apply the stored top-start coordinates after the
         // new size is known so expanding/collapsing Compose content does not jump on screen.
-        windowParams.x = windowParams.x.coerceIn(0, maxXCoordinate)
-        windowParams.y = windowParams.y.coerceIn(0, maxYCoordinate)
+        // Coordinates for other gravities are offsets with different semantics and must not be
+        // clamped as if they were absolute top-start positions.
+        if (windowParams.gravity == (Gravity.START or Gravity.TOP)) {
+            windowParams.x = windowParams.x.coerceIn(0, maxXCoordinate)
+            windowParams.y = windowParams.y.coerceIn(0, maxYCoordinate)
+        }
 
         try {
             scheduleCoordinateUpdate()
@@ -327,9 +344,16 @@ public abstract class CoreFloatingWindow internal constructor(
                     .alpha(INVISIBLE_ALPHA)
                     .setDuration(ANIMATION_DURATION)
                     .withEndAction {
+                        if (_isShowing.value) {
+                            return@withEndAction
+                        }
+
                         // Remove view after animation
                         try {
-                            windowManager.removeViewImmediate(decorView)
+                            if (decorView.parent != null) {
+                                windowManager.removeViewImmediate(decorView)
+                            }
+                            coordinateUpdateScheduled = false
                         } catch (e: Exception) {
                             Log.e(tag, "Error removing window: ${e.message}", e)
                         }
@@ -385,6 +409,16 @@ public abstract class CoreFloatingWindow internal constructor(
         }
     }
 
+    /** Creates a recomposer owned by this window rather than by a single view attachment. */
+    internal fun createWindowRecomposer(): Recomposer = Recomposer(coroutineContext).also { recomposer ->
+        // WindowManager detaches the decor view on every hide(). A lifecycle-aware window
+        // recomposer treats that detach as permanent destruction, so own the runner here and
+        // cancel it only when content is replaced or this floating window is closed.
+        lifecycleCoroutineScope.launch(start = CoroutineStart.UNDISPATCHED) {
+            recomposer.runRecomposeAndApplyChanges()
+        }
+    }
+
     /** Disposes the Compose composition and clears the reference. */
     internal fun disposeCompositionIfNeeded() {
         composeView?.let {
@@ -419,25 +453,28 @@ public abstract class CoreFloatingWindow internal constructor(
         }
         Log.d(tag, "Destroying window...")
 
-        // Hide the window if showing (ensures view is removed from WindowManager)
-        if (_isShowing.value) {
-            try {
-                _isShowing.update { false }
-                decorView.animate().cancel()
+        // Remove the view even when hide() has already marked it hidden but its fade-out has not
+        // finished yet.
+        val wasShowing = _isShowing.value
+        _isShowing.update { false }
+        try {
+            decorView.animate().cancel()
 
-                if (decorView.parent != null) {
-                    windowManager.removeViewImmediate(decorView)
-                } else {
-                    Log.w(tag, "Destroy called but DecorView has no parent.")
-                }
-
+            if (decorView.parent != null) {
+                windowManager.removeViewImmediate(decorView)
+            } else if (wasShowing) {
+                Log.w(tag, "Destroy called but DecorView has no parent.")
+            }
+        } catch (e: Exception) {
+            Log.e(
+                tag,
+                "Error hiding window during destruction: ${e.message}",
+                e,
+            )
+        } finally {
+            coordinateUpdateScheduled = false
+            if (wasShowing) {
                 lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
-            } catch (e: Exception) {
-                Log.e(
-                    tag,
-                    "Error hiding window during destruction: ${e.message}",
-                    e,
-                )
             }
         }
 

--- a/library/src/main/kotlin/com/github/only52607/compose/core/CoreFloatingWindow.kt
+++ b/library/src/main/kotlin/com/github/only52607/compose/core/CoreFloatingWindow.kt
@@ -1,9 +1,13 @@
 package com.github.only52607.compose.core
 
 import android.app.Application
+import android.content.BroadcastReceiver
 import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
 import android.os.Handler
 import android.os.Looper
+import android.os.PowerManager
 import android.provider.Settings
 import android.util.Log
 import android.view.Gravity
@@ -13,7 +17,9 @@ import android.widget.FrameLayout
 import androidx.compose.runtime.Recomposer
 import androidx.compose.ui.platform.AndroidUiDispatcher
 import androidx.compose.ui.platform.ComposeView
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.LifecycleRegistry
 import androidx.lifecycle.ViewModelStore
 import androidx.lifecycle.ViewModelStoreOwner
@@ -104,6 +110,43 @@ public abstract class CoreFloatingWindow internal constructor(
         private set
 
     private val windowManager = context.getSystemService(Context.WINDOW_SERVICE) as WindowManager
+
+    // --- Screen state ---
+
+    // The floating window lifecycle must mirror what an Activity gets for free: when the screen
+    // turns off, the UI is no longer visible, so lifecycle-aware work (state collection,
+    // animations) must stop. Otherwise the window keeps composing/measuring into an invisible
+    // surface while the screen is off, and the accumulated work bursts onto the first frames
+    // after the screen turns back on, which is felt as lag.
+    private var isScreenInteractive =
+        (context.getSystemService(Context.POWER_SERVICE) as? PowerManager)?.isInteractive ?: true
+
+    private val screenStateReceiver = object : BroadcastReceiver() {
+        override fun onReceive(receiverContext: Context?, intent: Intent?) {
+            when (intent?.action) {
+                Intent.ACTION_SCREEN_ON -> isScreenInteractive = true
+                Intent.ACTION_SCREEN_OFF -> isScreenInteractive = false
+                else -> return
+            }
+            Log.d(tag, "Screen interactive: $isScreenInteractive")
+            syncLifecycleWithScreenState()
+        }
+    }
+
+    /**
+     * Moves the lifecycle to RESUMED only while the window is both showing and the screen is
+     * interactive; otherwise drops it to CREATED (delivering ON_PAUSE/ON_STOP).
+     */
+    private fun syncLifecycleWithScreenState() {
+        if (_isDestroyed.value) {
+            return
+        }
+        if (_isShowing.value && isScreenInteractive) {
+            lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+        } else if (lifecycleRegistry.currentState.isAtLeast(Lifecycle.State.STARTED)) {
+            lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_STOP)
+        }
+    }
 
     /**
      * Helper class providing access to the display metrics for the floating window.
@@ -198,7 +241,8 @@ public abstract class CoreFloatingWindow internal constructor(
             // ON_RESUME in order). A shown floating window is the overlay equivalent of a resumed
             // Activity: lifecycle-aware collection such as collectAsStateWithLifecycle or
             // repeatOnLifecycle gated on STARTED or RESUMED must be active while it is visible.
-            lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME)
+            // If the screen is currently off, this stays STOPPED until ACTION_SCREEN_ON.
+            syncLifecycleWithScreenState()
             // Animate fade-in
             decorView.animate()
                 .alpha(VISIBLE_ALPHA)
@@ -401,6 +445,18 @@ public abstract class CoreFloatingWindow internal constructor(
         lifecycleRegistry.handleLifecycleEvent(Lifecycle.Event.ON_CREATE)
         // Enable SavedStateHandles for ViewModels
         enableSavedStateHandles()
+        // Follow the display's interactive state so lifecycle-aware work pauses while the
+        // screen is off. ACTION_SCREEN_ON/OFF are protected system broadcasts, so the receiver
+        // does not need to be exported.
+        ContextCompat.registerReceiver(
+            context,
+            screenStateReceiver,
+            IntentFilter().apply {
+                addAction(Intent.ACTION_SCREEN_ON)
+                addAction(Intent.ACTION_SCREEN_OFF)
+            },
+            ContextCompat.RECEIVER_NOT_EXPORTED,
+        )
         Log.d(tag, "FloatingWindow initialized.")
     }
 
@@ -413,6 +469,20 @@ public abstract class CoreFloatingWindow internal constructor(
 
     /** Creates a recomposer owned by this window rather than by a single view attachment. */
     internal fun createWindowRecomposer(): Recomposer = Recomposer(coroutineContext).also { recomposer ->
+        // Mirror androidx's lifecycle-aware window recomposer: keep the composition frame clock
+        // (which drives withFrameNanos-based animations) paused while the window is not STARTED,
+        // i.e. while it is hidden or the screen is off. Recomposition from state changes still
+        // runs through the parent frame clock, so content stays current across hide()/show().
+        recomposer.pauseCompositionFrameClock()
+        val frameClockObserver = LifecycleEventObserver { _, event ->
+            when (event) {
+                Lifecycle.Event.ON_START -> recomposer.resumeCompositionFrameClock()
+                Lifecycle.Event.ON_STOP -> recomposer.pauseCompositionFrameClock()
+                else -> Unit
+            }
+        }
+        lifecycle.addObserver(frameClockObserver)
+
         // WindowManager detaches the decor view on every hide(). A lifecycle-aware window
         // recomposer treats that detach as permanent destruction, so own the runner here and
         // cancel it only when content is replaced or this floating window is closed.
@@ -431,6 +501,8 @@ public abstract class CoreFloatingWindow internal constructor(
                         "will no longer update. Call setContent() again to recover.",
                     e,
                 )
+            } finally {
+                lifecycle.removeObserver(frameClockObserver)
             }
         }
     }
@@ -468,6 +540,12 @@ public abstract class CoreFloatingWindow internal constructor(
             return
         }
         Log.d(tag, "Destroying window...")
+
+        try {
+            context.unregisterReceiver(screenStateReceiver)
+        } catch (e: IllegalArgumentException) {
+            Log.w(tag, "Screen state receiver was not registered: ${e.message}")
+        }
 
         // Remove the view even when hide() has already marked it hidden but its fade-out has not
         // finished yet.

--- a/library/src/main/kotlin/com/github/only52607/compose/core/CoreFloatingWindow.kt
+++ b/library/src/main/kotlin/com/github/only52607/compose/core/CoreFloatingWindow.kt
@@ -16,6 +16,7 @@ import android.view.ViewGroup
 import android.view.WindowManager
 import android.widget.FrameLayout
 import androidx.compose.runtime.Recomposer
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.ui.MotionDurationScale
 import androidx.compose.ui.platform.AndroidUiDispatcher
 import androidx.compose.ui.platform.ComposeView
@@ -684,13 +685,13 @@ private class SystemMotionDurationScale(context: Context) : MotionDurationScale,
     private val animationScaleUri =
         Settings.Global.getUriFor(Settings.Global.ANIMATOR_DURATION_SCALE)
 
-    @Volatile
-    override var scaleFactor: Float = readScaleFactor()
-        private set
+    private val scaleFactorState = mutableFloatStateOf(readScaleFactor())
+    override val scaleFactor: Float
+        get() = scaleFactorState.floatValue
 
     private val observer = object : ContentObserver(Handler(Looper.getMainLooper())) {
         override fun onChange(selfChange: Boolean) {
-            scaleFactor = readScaleFactor()
+            scaleFactorState.floatValue = readScaleFactor()
         }
     }
 

--- a/library/src/main/kotlin/com/github/only52607/compose/core/LayoutParams.kt
+++ b/library/src/main/kotlin/com/github/only52607/compose/core/LayoutParams.kt
@@ -31,12 +31,12 @@ internal fun defaultLayoutParams(context: Context) = WindowManager.LayoutParams(
     width = WindowManager.LayoutParams.WRAP_CONTENT
     format = PixelFormat.TRANSLUCENT
     gravity = Gravity.START or Gravity.TOP
-    flags =
-        (
-            WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL // Allows touches to pass through
-                or WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE // Prevents the window from taking focus (e.g., keyboard)
-                or WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED
-            )
+    flags = (
+        WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL // Allows touches to pass through
+            // Prevents the window from taking focus (e.g., keyboard)
+            or WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
+            or WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED
+        )
     // FLAG_HARDWARE_ACCELERATED: windows added directly through WindowManager.addView are
     // software-rendered by default (only Activity windows inherit acceleration from the theme).
     // Modern Compose backs its layers with RenderNodes via GraphicsContext even when the host

--- a/library/src/main/kotlin/com/github/only52607/compose/core/LayoutParams.kt
+++ b/library/src/main/kotlin/com/github/only52607/compose/core/LayoutParams.kt
@@ -34,8 +34,16 @@ internal fun defaultLayoutParams(context: Context) = WindowManager.LayoutParams(
     flags =
         (
             WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL // Allows touches to pass through
-                or WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE
-            ) // Prevents the window from taking focus (e.g., keyboard)
+                or WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE // Prevents the window from taking focus (e.g., keyboard)
+                or WindowManager.LayoutParams.FLAG_HARDWARE_ACCELERATED
+            )
+    // FLAG_HARDWARE_ACCELERATED: windows added directly through WindowManager.addView are
+    // software-rendered by default (only Activity windows inherit acceleration from the theme).
+    // Modern Compose backs its layers with RenderNodes via GraphicsContext even when the host
+    // window is not hardware accelerated, and that combination can leave recomposed content
+    // stale on screen until something else forces a window traversal (e.g. updateViewLayout
+    // during a drag). Hardware acceleration must be requested before addView; it cannot be
+    // enabled later.
 
     // Set window type correctly for overlays
     // Requires SYSTEM_ALERT_WINDOW permission

--- a/library/src/main/kotlin/com/github/only52607/compose/service/ComposeServiceFloatingWindow.kt
+++ b/library/src/main/kotlin/com/github/only52607/compose/service/ComposeServiceFloatingWindow.kt
@@ -52,7 +52,7 @@ public class ComposeServiceFloatingWindow(
      * Sets the Jetpack Compose content for the floating window.
      *
      * This method creates a [ComposeView] and sets your [content] within it.
-     * It also sets up the necessary CompositionLocal provider for [LocalFloatingWindow]
+     * It also sets up the necessary CompositionLocal provider for [LocalServiceFloatingWindow]
      * and connects the view to this window's lifecycle, ViewModel store, and saved state registry.
      *
      * @param content The composable function defining the UI of the floating window.

--- a/library/src/main/kotlin/com/github/only52607/compose/service/ComposeServiceFloatingWindow.kt
+++ b/library/src/main/kotlin/com/github/only52607/compose/service/ComposeServiceFloatingWindow.kt
@@ -7,10 +7,8 @@ import android.util.Log
 import android.view.WindowManager
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.Recomposer
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.compose.ui.platform.createLifecycleAwareWindowRecomposer
 import androidx.core.view.isNotEmpty
 import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.lifecycle.setViewTreeViewModelStoreOwner
@@ -74,12 +72,8 @@ public class ComposeServiceFloatingWindow(
                 ViewCompositionStrategy.DisposeOnLifecycleDestroyed(lifecycle),
             )
 
-            // ComposeView is hosted directly by WindowManager, so install a lifecycle-aware
-            // recomposer instead of relying on an Activity window recomposer.
-            val recomposer = createLifecycleAwareWindowRecomposer(
-                coroutineContext = this@ComposeServiceFloatingWindow.coroutineContext,
-                lifecycle = lifecycle,
-            )
+            // Keep the recomposer alive while WindowManager detaches the view during hide().
+            val recomposer = this@ComposeServiceFloatingWindow.createWindowRecomposer()
             setParentCompositionContext(recomposer)
             parentComposition = recomposer // Store for later disposal
 

--- a/library/src/main/kotlin/com/github/only52607/compose/service/ComposeServiceFloatingWindow.kt
+++ b/library/src/main/kotlin/com/github/only52607/compose/service/ComposeServiceFloatingWindow.kt
@@ -17,16 +17,23 @@ import com.github.only52607.compose.core.CoreFloatingWindow
 import com.github.only52607.compose.core.defaultLayoutParams
 
 /**
- * Manages a floating window that can display Jetpack Compose content overlaying other applications.
+ * Hosts Jetpack Compose content in a floating window created from a service or application context.
  *
- * This class handles the lifecycle, state saving, ViewModel scope, and WindowManager interactions
- * necessary for a floating Compose UI. It implements [AutoCloseable], allowing it to be used
- * with Kotlin's `use` function for automatic resource cleanup.
+ * The default [windowParams] create a hardware-accelerated application-overlay window. This class
+ * supplies Compose with this window's lifecycle, [androidx.lifecycle.ViewModelStore], saved-state
+ * registry, and [LocalServiceFloatingWindow]. The composition and its window-owned recomposer are
+ * retained across [hide][CoreFloatingWindow.hide] and [show][CoreFloatingWindow.show], while
+ * frame-driven effects pause when the window is hidden or the screen is off.
+ *
+ * Call [close][CoreFloatingWindow.close] when the service no longer needs the window. Closing
+ * detaches the view, disposes the composition, destroys scoped ViewModels, and releases registered
+ * receivers and observers. The class implements [AutoCloseable] for callers with a naturally
+ * bounded lifetime.
  *
  * Example usage with `use`:
  * ```kotlin
  * val floatingWindow = ComposeServiceFloatingWindow(context)
- * floatingWindow.use { window -> // destroy() is called automatically at the end of this block
+ * floatingWindow.use { window -> // close() is called automatically at the end of this block
  *     window.setContent { /* Your Composable UI */ }
  *     window.show()
  *     // ... interact with the window ...
@@ -36,10 +43,10 @@ import com.github.only52607.compose.core.defaultLayoutParams
  * Remember to declare the `SYSTEM_ALERT_WINDOW` permission in your AndroidManifest.xml and
  * request it at runtime if targeting Android M (API 23) or higher.
  *
- * @param context The context used for creating the window and accessing system services.
- *                An application context is preferred to avoid leaks.
- * @param windowParams The layout parameters for the floating window. Defaults are provided
- *                     by [ComposeServiceFloatingWindow.defaultLayoutParams].
+ * @param context Context used to create the Compose view and access [WindowManager]. Prefer a
+ * service or application context whose lifetime covers the window.
+ * @param windowParams Layout parameters used to attach and update the window. The default requests
+ * a hardware-accelerated, non-focusable application overlay with wrap-content dimensions.
  */
 public class ComposeServiceFloatingWindow(
     private val context: Context,
@@ -49,14 +56,16 @@ public class ComposeServiceFloatingWindow(
     tag = SERVICE_TAG,
 ) {
     /**
-     * Sets the Jetpack Compose content for the floating window.
+     * Sets or replaces the Compose content owned by this window.
      *
-     * This method creates a [ComposeView] and sets your [content] within it.
-     * It also sets up the necessary CompositionLocal provider for [LocalServiceFloatingWindow]
-     * and connects the view to this window's lifecycle, ViewModel store, and saved state registry.
+     * The new [ComposeView] receives this window's lifecycle, ViewModel store, saved-state registry,
+     * and [LocalServiceFloatingWindow]. Its recomposer survives normal WindowManager detach/reattach
+     * cycles and follows the window lifecycle for frame-clock pausing. Replacing existing content
+     * disposes the previous composition and recomposer. If the window is already showing, its
+     * layout is updated after replacement.
      *
      * @param content The composable function defining the UI of the floating window.
-     * @throws IllegalStateException if called after [checkDestroyed] or [close] has been invoked.
+     * @throws IllegalStateException if called after [close][CoreFloatingWindow.close].
      */
     public fun setContent(content: @Composable () -> Unit) {
         checkDestroyed()

--- a/library/src/main/kotlin/com/github/only52607/compose/window/ComposeFloatingWindow.kt
+++ b/library/src/main/kotlin/com/github/only52607/compose/window/ComposeFloatingWindow.kt
@@ -6,10 +6,8 @@ import android.util.Log
 import android.view.WindowManager
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.Recomposer
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
-import androidx.compose.ui.platform.createLifecycleAwareWindowRecomposer
 import androidx.core.view.isNotEmpty
 import androidx.lifecycle.HasDefaultViewModelProviderFactory
 import androidx.lifecycle.SavedStateViewModelFactory
@@ -86,12 +84,8 @@ public class ComposeFloatingWindow(
                 ViewCompositionStrategy.DisposeOnLifecycleDestroyed(lifecycle),
             )
 
-            // ComposeView is hosted directly by WindowManager, so install a lifecycle-aware
-            // recomposer instead of relying on an Activity window recomposer.
-            val recomposer = createLifecycleAwareWindowRecomposer(
-                coroutineContext = this@ComposeFloatingWindow.coroutineContext,
-                lifecycle = lifecycle,
-            )
+            // Keep the recomposer alive while WindowManager detaches the view during hide().
+            val recomposer = this@ComposeFloatingWindow.createWindowRecomposer()
             setParentCompositionContext(recomposer)
             parentComposition = recomposer // Store for later disposal
 

--- a/library/src/main/kotlin/com/github/only52607/compose/window/ComposeFloatingWindow.kt
+++ b/library/src/main/kotlin/com/github/only52607/compose/window/ComposeFloatingWindow.kt
@@ -10,10 +10,14 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import androidx.core.view.isNotEmpty
 import androidx.lifecycle.HasDefaultViewModelProviderFactory
+import androidx.lifecycle.SAVED_STATE_REGISTRY_OWNER_KEY
 import androidx.lifecycle.SavedStateViewModelFactory
+import androidx.lifecycle.VIEW_MODEL_STORE_OWNER_KEY
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.setViewTreeLifecycleOwner
 import androidx.lifecycle.setViewTreeViewModelStoreOwner
+import androidx.lifecycle.viewmodel.CreationExtras
+import androidx.lifecycle.viewmodel.MutableCreationExtras
 import androidx.savedstate.setViewTreeSavedStateRegistryOwner
 import com.github.only52607.compose.core.CoreFloatingWindow
 import com.github.only52607.compose.core.defaultLayoutParams
@@ -58,6 +62,18 @@ public class ComposeFloatingWindow(
             this@ComposeFloatingWindow,
             null,
         )
+    }
+
+    override val defaultViewModelCreationExtras: CreationExtras = MutableCreationExtras().apply {
+        val application = context.applicationContext as? Application
+        if (application != null) {
+            set(
+                ViewModelProvider.AndroidViewModelFactory.APPLICATION_KEY,
+                application,
+            )
+        }
+        set(SAVED_STATE_REGISTRY_OWNER_KEY, this@ComposeFloatingWindow)
+        set(VIEW_MODEL_STORE_OWNER_KEY, this@ComposeFloatingWindow)
     }
 
     /**

--- a/library/src/main/kotlin/com/github/only52607/compose/window/ComposeFloatingWindow.kt
+++ b/library/src/main/kotlin/com/github/only52607/compose/window/ComposeFloatingWindow.kt
@@ -23,16 +23,25 @@ import com.github.only52607.compose.core.CoreFloatingWindow
 import com.github.only52607.compose.core.defaultLayoutParams
 
 /**
- * Manages a floating window that can display Jetpack Compose content overlaying other applications.
+ * Hosts Jetpack Compose content in a lifecycle-aware floating overlay window.
  *
- * This class handles the lifecycle, state saving, ViewModel scope, and WindowManager interactions
- * necessary for a floating Compose UI. It implements [AutoCloseable], allowing it to be used
- * with Kotlin's `use` function for automatic resource cleanup.
+ * With the recommended application context, the default [windowParams] create a
+ * hardware-accelerated application-overlay window. This class supplies Compose with this window's
+ * lifecycle, ViewModel store, saved-state registry, default [ViewModelProvider.Factory], creation
+ * extras for `SavedStateHandle` and `AndroidViewModel`, and [LocalFloatingWindow]. The composition
+ * and its window-owned recomposer are retained across [hide][CoreFloatingWindow.hide] and
+ * [show][CoreFloatingWindow.show], while frame-driven effects pause when the window is hidden or
+ * the screen is off.
+ *
+ * Call [close][CoreFloatingWindow.close] when the window is no longer needed. Closing detaches the
+ * view, disposes the composition, destroys scoped ViewModels, and releases registered receivers
+ * and observers. The class implements [AutoCloseable] for callers with a naturally bounded
+ * lifetime.
  *
  * Example usage with `use`:
  * ```kotlin
  * val floatingWindow = ComposeFloatingWindow(context)
- * floatingWindow.use { window -> // destroy() is called automatically at the end of this block
+ * floatingWindow.use { window -> // close() is called automatically at the end of this block
  *     window.setContent { /* Your Composable UI */ }
  *     window.show()
  *     // ... interact with the window ...
@@ -42,10 +51,10 @@ import com.github.only52607.compose.core.defaultLayoutParams
  * Remember to declare the `SYSTEM_ALERT_WINDOW` permission in your AndroidManifest.xml and
  * request it at runtime if targeting Android M (API 23) or higher.
  *
- * @param context The context used for creating the window and accessing system services.
- *                An application context is preferred to avoid leaks.
- * @param windowParams The layout parameters for the floating window. Defaults are provided
- *                     by [ComposeFloatingWindow.defaultLayoutParams].
+ * @param context Context used to create the Compose view and access [WindowManager]. Prefer an
+ * application context whose lifetime covers the window.
+ * @param windowParams Layout parameters used to attach and update the window. The default requests
+ * a hardware-accelerated, non-focusable application overlay with wrap-content dimensions.
  */
 public class ComposeFloatingWindow(
     private val context: Context,
@@ -77,14 +86,16 @@ public class ComposeFloatingWindow(
     }
 
     /**
-     * Sets the Jetpack Compose content for the floating window.
+     * Sets or replaces the Compose content owned by this window.
      *
-     * This method creates a [ComposeView] and sets your [content] within it.
-     * It also sets up the necessary CompositionLocal provider for [LocalFloatingWindow]
-     * and connects the view to this window's lifecycle, ViewModel store, and saved state registry.
+     * The new [ComposeView] receives this window's lifecycle, ViewModel store, saved-state registry,
+     * default ViewModel factory and creation extras, and [LocalFloatingWindow]. Its recomposer
+     * survives normal WindowManager detach/reattach cycles and follows the window lifecycle for
+     * frame-clock pausing. Replacing existing content disposes the previous composition and
+     * recomposer. If the window is already showing, its layout is updated after replacement.
      *
      * @param content The composable function defining the UI of the floating window.
-     * @throws IllegalStateException if called after [checkDestroyed] or [close] has been invoked.
+     * @throws IllegalStateException if called after [close][CoreFloatingWindow.close].
      */
     public fun setContent(content: @Composable () -> Unit) {
         checkDestroyed()


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Make sure to follow the contributing guidelines. -->
<!-- Important note, we may remove your pull request if you do not use this provided PR template correctly. -->

## Pull Request Type
<!-- Please select what type of pull request this is: [x] -->

- [ ] Chore
- [X] Bugfix
- [ ] Feature Implementation
- [ ] Documentation
- [ ] Other

## Related issue
<!-- Please link the issue your pull request is referring to. -->
<!-- If this pull request fully resolves the relevant issue, put "closes" before the issue number. -->
<!-- Example: "closes #123456". -->

## Description
<!-- Please write a clear and concise description of what the pull request does. -->
- Replaced createLifecycleAwareWindowRecomposer with a window-owned recomposer in [CoreFloatingWindow.kt](library/src/main/kotlin/com/github/only52607/compose/core/CoreFloatingWindow.kt#L412-L420). AndroidX permanently cancels lifecycle-aware recomposers when hide() detaches the view, causing frozen content and dialogs after showing again.
- Both [ComposeFloatingWindow](library/src/main/kotlin/com/github/only52607/compose/window/ComposeFloatingWindow.kt#L79-L100) and [ComposeServiceFloatingWindow](library/src/main/kotlin/com/github/only52607/compose/service/ComposeServiceFloatingWindow.kt#L67-L88) now use the corrected recomposer lifecycle.
- Reset stale frame-update scheduling after detach, preventing coordinate updates from becoming permanently blocked.
- Avoided incorrectly clamping coordinates when callers use custom gravity instead of START | TOP.
- Fixed rapid hide() → show() calls so the pending fade-out cannot detach a newly reshown window.
- Made close() reliably remove a window even while its hide animation is still running.
- Added regression coverage for recomposition after hide/show and rapid hide/show.

## Screenshots <!-- If appropriate -->
<!-- Please add before and after screenshots if there is a visible change. -->

## Testing <!-- for code that is not small enough to be easily understandable -->
<!-- Has this pull request been tested? -->
<!-- Please describe shortly how you tested it. -->
<!-- Are there any ramifications remaining? -->

## Additional context
<!-- Add any other context about the pull request here. -->
